### PR TITLE
feat: implement viewdu

### DIFF
--- a/packages/persistent-merkle-tree/src/common.zig
+++ b/packages/persistent-merkle-tree/src/common.zig
@@ -1,0 +1,5 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const AllocatorError = Allocator.Error;
+const nm = @import("./node.zig");
+pub const TreeError = nm.NodeError || error{InvalidLength};

--- a/packages/persistent-merkle-tree/src/node.zig
+++ b/packages/persistent-merkle-tree/src/node.zig
@@ -14,7 +14,7 @@ pub const Node = union(NodeType) {
     Zero: ZeroNode,
 };
 
-pub const NodeError = error{ OutOfMemory, NoLeft, NoRight };
+pub const NodeError = error{ OutOfMemory, NoLeft, NoRight, OutOfBounds, CannotSetBranchNode, CannotGetUintBranchNode };
 
 pub const BranchNode = struct {
     // cannot use const here because it's designed to be reused

--- a/packages/persistent-merkle-tree/src/root.zig
+++ b/packages/persistent-merkle-tree/src/root.zig
@@ -15,6 +15,7 @@ pub const Tree = @import("./tree.zig").Tree;
 pub const subtreeFillToContents = @import("./subtree.zig").subtreeFillToContents;
 pub const getNodeAtDepth = @import("./tree.zig").getNodeAtDepth;
 pub const Node = @import("./node.zig").Node;
+pub const getRoot = @import("./node.zig").getRoot;
 // TODO: publish more apis inside Tree if needed
 
 test {

--- a/packages/persistent-merkle-tree/src/root.zig
+++ b/packages/persistent-merkle-tree/src/root.zig
@@ -13,6 +13,7 @@ pub const HashError = @import("./sha256.zig").HashError;
 pub const NodePool = @import("./pool.zig").NodePool;
 pub const Tree = @import("./tree.zig").Tree;
 pub const subtreeFillToContents = @import("./subtree.zig").subtreeFillToContents;
+pub const TreeError = @import("./common.zig").TreeError;
 pub const getNodeAtDepth = @import("./tree.zig").getNodeAtDepth;
 pub const Node = @import("./node.zig").Node;
 pub const getRoot = @import("./node.zig").getRoot;

--- a/packages/persistent-merkle-tree/src/root.zig
+++ b/packages/persistent-merkle-tree/src/root.zig
@@ -13,6 +13,8 @@ pub const HashError = @import("./sha256.zig").HashError;
 pub const NodePool = @import("./pool.zig").NodePool;
 pub const Tree = @import("./tree.zig").Tree;
 pub const subtreeFillToContents = @import("./subtree.zig").subtreeFillToContents;
+pub const getNodeAtDepth = @import("./tree.zig").getNodeAtDepth;
+pub const Node = @import("./node.zig").Node;
 // TODO: publish more apis inside Tree if needed
 
 test {

--- a/packages/persistent-merkle-tree/src/subtree.zig
+++ b/packages/persistent-merkle-tree/src/subtree.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
 const nm = @import("./node.zig");
 const Node = nm.Node;
+const TreeError = @import("./common.zig").TreeError;
 const NodePool = @import("./pool.zig").NodePool;
 const getNodesAtDepth = @import("./tree.zig").getNodesAtDepth;
 
-pub fn subtreeFillToDepth(pool: *NodePool, bottom: *Node, depth: usize) !*Node {
+pub fn subtreeFillToDepth(pool: *NodePool, bottom: *Node, depth: usize) nm.NodeError!*Node {
     var d = depth;
     var node = bottom;
     while (d > 0) : (d -= 1) {
@@ -14,7 +15,7 @@ pub fn subtreeFillToDepth(pool: *NodePool, bottom: *Node, depth: usize) !*Node {
     return node;
 }
 
-pub fn subtreeFillToLength(pool: *NodePool, bottom: *Node, depth: usize, length: usize) !*Node {
+pub fn subtreeFillToLength(pool: *NodePool, bottom: *Node, depth: usize, length: usize) nm.NodeError!*Node {
     const max_length = 1 << depth;
     if (length > max_length) {
         return error.InvalidLength;
@@ -52,7 +53,7 @@ pub fn subtreeFillToLength(pool: *NodePool, bottom: *Node, depth: usize, length:
 /// WARNING: Mutates the provided nodes array.
 /// TODO: Don't mutate the nodes array.
 /// TODO: HashComputation
-pub fn subtreeFillToContents(pool: *NodePool, nodes: []*Node, depth: usize) !*Node {
+pub fn subtreeFillToContents(pool: *NodePool, nodes: []*Node, depth: usize) TreeError!*Node {
     const max_length: usize = std.math.pow(usize, 2, depth);
     if (nodes.len > max_length) {
         return error.InvalidLength;

--- a/packages/ssz/src/type/boolean.zig
+++ b/packages/ssz/src/type/boolean.zig
@@ -34,7 +34,7 @@ pub const BooleanType = struct {
     }
 
     /// recursive function
-    pub fn allocateViewDU(_: Allocator, node: *Node) bool {
+    pub fn allocateViewDU(_: Allocator, node: *Node) !bool {
         return @This().getViewDU(node);
     }
 

--- a/packages/ssz/src/type/boolean.zig
+++ b/packages/ssz/src/type/boolean.zig
@@ -7,8 +7,8 @@ const JsonError = @import("./common.zig").JsonError;
 const SszError = @import("./common.zig").SszError;
 const HashError = @import("./common.zig").HashError;
 const SingleType = @import("./single.zig").withType(bool);
-const Node = @import("hash").Node;
-const getRoot = @import("hash").getRoot;
+const Node = @import("persistent_merkle_tree").Node;
+const getRoot = @import("persistent_merkle_tree").getRoot;
 
 pub const BooleanType = struct {
     byte_len: usize,

--- a/packages/ssz/src/type/boolean.zig
+++ b/packages/ssz/src/type/boolean.zig
@@ -38,7 +38,7 @@ pub const BooleanType = struct {
     }
 
     /// recursive function
-    pub fn allocateViewDU(_: Allocator, node: *Node) !bool {
+    pub fn allocateViewDU(_: *const @This(), _: Allocator, node: *Node) !bool {
         return @This().getViewDU(node);
     }
 

--- a/packages/ssz/src/type/boolean.zig
+++ b/packages/ssz/src/type/boolean.zig
@@ -20,6 +20,10 @@ pub const BooleanType = struct {
         return bool;
     }
 
+    pub fn getViewDUType() type {
+        return bool;
+    }
+
     pub fn getZigTypeAlignment() usize {
         return 1;
     }

--- a/packages/ssz/src/type/boolean.zig
+++ b/packages/ssz/src/type/boolean.zig
@@ -7,6 +7,8 @@ const JsonError = @import("./common.zig").JsonError;
 const SszError = @import("./common.zig").SszError;
 const HashError = @import("./common.zig").HashError;
 const SingleType = @import("./single.zig").withType(bool);
+const Node = @import("hash").Node;
+const getRoot = @import("hash").getRoot;
 
 pub const BooleanType = struct {
     byte_len: usize,
@@ -22,6 +24,18 @@ pub const BooleanType = struct {
 
     pub fn getViewDUType() type {
         return bool;
+    }
+
+    /// public api
+    pub fn getViewDU(node: *Node) bool {
+        const root = getRoot(node);
+        // TODO: check typescript's implementation
+        return root[0] != 0;
+    }
+
+    /// recursive function
+    pub fn allocateViewDU(_: Allocator, node: *Node) bool {
+        return @This().getViewDU(node);
     }
 
     pub fn getZigTypeAlignment() usize {

--- a/packages/ssz/src/type/common.zig
+++ b/packages/ssz/src/type/common.zig
@@ -4,9 +4,11 @@ const Allocator = std.mem.Allocator;
 const AllocatorError = Allocator.Error;
 const NextError = Scanner.NextError;
 const FromHexError = @import("util").FromHexError;
+const TreeError = @import("persistent_merkle_tree").TreeError;
 
 pub const ScannerError = NextError;
 pub const ParseUIntError = error{ InvalidNumber, Overflow, InvalidChacter } || std.fmt.ParseIntError || std.fmt.ParseFloatError || AllocatorError || ScannerError;
 pub const JsonError = ParseUIntError || FromHexError || error{ InvalidJson, InCorrectLen, InvalidLength };
-pub const SszError = AllocatorError || error{ OutOfMemory, InCorrectLen, InvalidLength } || error{ invalidFixedSize, zeroOffset, offsetNotDivisibleBy4, offsetOutOfRange, offsetNotIncreasing, InvalidSsz };
+pub const SszError = AllocatorError || error{ OutOfMemory, InCorrectLen, InvalidLength } || error{ invalidFixedSize, zeroOffset, offsetNotDivisibleBy4, offsetOutOfRange, offsetNotIncreasing, InvalidSsz } || error{MissingPool};
 pub const HashError = error{ InCorrectLen, InvalidInput, noInitZeroHash, OutOfBounds, OutOfMemory };
+pub const ViewDUError = SszError || TreeError || error{MissingPool};

--- a/packages/ssz/src/type/container.zig
+++ b/packages/ssz/src/type/container.zig
@@ -12,10 +12,10 @@ const JsonError = @import("./common.zig").JsonError;
 const SszError = @import("./common.zig").SszError;
 const HashError = @import("./common.zig").HashError;
 const Parsed = @import("./type.zig").Parsed;
-const Node = @import("hash").Node;
-const getNodeAtDepth = @import("hash").getNodeAtDepth;
-const maxChunksToDepth = @import("hash").maxChunksToDepth;
-const NodePool = @import("hash").NodePool;
+const Node = @import("persistent_merkle_tree").Node;
+const getNodeAtDepth = @import("persistent_merkle_tree").getNodeAtDepth;
+const maxChunksToDepth = @import("persistent_merkle_tree").maxChunksToDepth;
+const NodePool = @import("persistent_merkle_tree").NodePool;
 
 const BytesRange = struct {
     start: usize,

--- a/packages/ssz/src/type/list_basic.zig
+++ b/packages/ssz/src/type/list_basic.zig
@@ -157,7 +157,7 @@ test "deserializeFromBytes" {
     // uint of 8 bytes = u64
     const UintType = @import("./uint.zig").createUintType(8);
     const ListBasicType = createListBasicType(UintType);
-    var uintType = try UintType.init();
+    var uintType = try UintType.init(null);
     var listType = try ListBasicType.init(allocator, &uintType, 128, 128);
     defer uintType.deinit();
     defer listType.deinit();
@@ -215,7 +215,7 @@ test "deserializeFromJson" {
     // uint of 8 bytes = u64
     const UintType = @import("./uint.zig").createUintType(8);
     const ListBasicType = createListBasicType(UintType);
-    var uintType = try UintType.init();
+    var uintType = try UintType.init(null);
     var listType = try ListBasicType.init(allocator, &uintType, 4, 2);
     defer uintType.deinit();
     defer listType.deinit();

--- a/packages/ssz/src/type/list_composite.zig
+++ b/packages/ssz/src/type/list_composite.zig
@@ -217,9 +217,9 @@ test "ListCompositeType - element type is ContainerType" {
     const ZigContainerType = SSZContainerType.getZigType();
     const ListCompositeType = createListCompositeType(SSZContainerType);
 
-    const uintType = try UintType.init();
+    const uintType = try UintType.init(null);
     defer uintType.deinit();
-    var elementType = try SSZContainerType.init(allocator, .{ .a = uintType, .b = uintType });
+    var elementType = try SSZContainerType.init(allocator, .{ .a = uintType, .b = uintType }, null);
     defer elementType.deinit();
 
     var listType = try ListCompositeType.init(allocator, &elementType, 128, 64);
@@ -303,7 +303,7 @@ test "ListCompositeType - element type is ListBasicType" {
 
     const ListCompositeType = createListCompositeType(SSZListBasicType);
 
-    var uintType = try UintType.init();
+    var uintType = try UintType.init(null);
     defer uintType.deinit();
     var elementType = try SSZListBasicType.init(allocator, &uintType, 2, 2);
     defer elementType.deinit();

--- a/packages/ssz/src/type/uint.zig
+++ b/packages/ssz/src/type/uint.zig
@@ -38,6 +38,10 @@ pub fn createUintType(comptime num_bytes: usize) type {
             return T;
         }
 
+        pub fn getViewDUType() type {
+            return T;
+        }
+
         pub fn getZigTypeAlignment() usize {
             return num_bytes;
         }

--- a/packages/ssz/src/type/uint.zig
+++ b/packages/ssz/src/type/uint.zig
@@ -8,8 +8,8 @@ const JsonError = @import("./common.zig").JsonError;
 const SszError = @import("./common.zig").SszError;
 const HashError = @import("./common.zig").HashError;
 const Parsed = @import("./type.zig").Parsed;
-const Node = @import("hash").Node;
-const getRoot = @import("hash").getRoot;
+const Node = @import("persistent_merkle_tree").Node;
+const getRoot = @import("persistent_merkle_tree").getRoot;
 
 pub fn createUintType(comptime num_bytes: usize) type {
     if (num_bytes != 1 and num_bytes != 2 and num_bytes != 4 and num_bytes != 8 and num_bytes != 16 and num_bytes != 32 and num_bytes != 64) {

--- a/packages/ssz/src/type/uint.zig
+++ b/packages/ssz/src/type/uint.zig
@@ -57,7 +57,7 @@ pub fn createUintType(comptime num_bytes: usize) type {
         }
 
         /// recursive function
-        pub fn allocateViewDU(_: Allocator, node: *Node) !T {
+        pub fn allocateViewDU(_: *const @This(), _: Allocator, node: *Node) !T {
             return @This().getViewDU(node);
         }
 

--- a/packages/ssz/src/type/uint.zig
+++ b/packages/ssz/src/type/uint.zig
@@ -8,6 +8,8 @@ const JsonError = @import("./common.zig").JsonError;
 const SszError = @import("./common.zig").SszError;
 const HashError = @import("./common.zig").HashError;
 const Parsed = @import("./type.zig").Parsed;
+const Node = @import("hash").Node;
+const getRoot = @import("hash").getRoot;
 
 pub fn createUintType(comptime num_bytes: usize) type {
     if (num_bytes != 1 and num_bytes != 2 and num_bytes != 4 and num_bytes != 8 and num_bytes != 16 and num_bytes != 32 and num_bytes != 64) {
@@ -40,6 +42,19 @@ pub fn createUintType(comptime num_bytes: usize) type {
 
         pub fn getViewDUType() type {
             return T;
+        }
+
+        /// public api
+        pub fn getViewDU(node: *Node) T {
+            const hash = getRoot(node);
+            const sliceT = std.mem.bytesAsSlice(T, hash[0..]);
+            const value = sliceT[0];
+            return if (native_endian == .big) @byteSwap(value) else value;
+        }
+
+        /// recursive function
+        pub fn allocateViewDU(_: Allocator, node: *Node) T {
+            return @This().getViewDU(node);
         }
 
         pub fn getZigTypeAlignment() usize {

--- a/packages/ssz/src/type/uint.zig
+++ b/packages/ssz/src/type/uint.zig
@@ -53,7 +53,7 @@ pub fn createUintType(comptime num_bytes: usize) type {
         }
 
         /// recursive function
-        pub fn allocateViewDU(_: Allocator, node: *Node) T {
+        pub fn allocateViewDU(_: Allocator, node: *Node) !T {
             return @This().getViewDU(node);
         }
 

--- a/packages/ssz/src/type/vector_basic.zig
+++ b/packages/ssz/src/type/vector_basic.zig
@@ -156,7 +156,7 @@ test "deserializeFromBytes" {
     // uint of 8 bytes = u64
     const UintType = @import("./uint.zig").createUintType(8);
     const VectorBasicType = createVectorBasicType(UintType);
-    var uintType = try UintType.init();
+    var uintType = try UintType.init(null);
     var vectorType = try VectorBasicType.init(allocator, &uintType, 8);
     defer uintType.deinit();
     defer vectorType.deinit();
@@ -210,7 +210,7 @@ test "deserializeFromJson" {
     // uint of 8 bytes = u64
     const UintType = @import("./uint.zig").createUintType(8);
     const VectorBasicType = createVectorBasicType(UintType);
-    var uintType = try UintType.init();
+    var uintType = try UintType.init(null);
     var vectorType = try VectorBasicType.init(allocator, &uintType, 4);
     defer uintType.deinit();
     defer vectorType.deinit();

--- a/packages/ssz/src/type/vector_composite.zig
+++ b/packages/ssz/src/type/vector_composite.zig
@@ -193,7 +193,7 @@ test "fromJson - VectorCompositeType of 4 roots" {
 test "fromJson - VectorCompositeType of 4 ContainerType({a: uint64Type, b: uint64Type})" {
     const allocator = std.testing.allocator;
     const UintType = @import("./uint.zig").createUintType(8);
-    const uintType = try UintType.init();
+    const uintType = try UintType.init(null);
     defer uintType.deinit();
 
     const SszType = struct {
@@ -202,7 +202,7 @@ test "fromJson - VectorCompositeType of 4 ContainerType({a: uint64Type, b: uint6
     };
 
     const ContainerType = @import("./container.zig").createContainerType(SszType, sha256Hash);
-    var containerType = try ContainerType.init(allocator, SszType{ .a = uintType, .b = uintType });
+    var containerType = try ContainerType.init(allocator, SszType{ .a = uintType, .b = uintType }, null);
     defer containerType.deinit();
 
     const VectorCompositeType = createVectorCompositeType(ContainerType);

--- a/packages/ssz/test/int/type/byte_list.zig
+++ b/packages/ssz/test/int/type/byte_list.zig
@@ -83,7 +83,7 @@ test "ListBasicType[u8, 256]" {
     // uint of 1 bytes = u8
     const UintType = createUintType(1);
     const ListBasicType = createListBasicType(UintType);
-    var uintType = try UintType.init();
+    var uintType = try UintType.init(null);
     var list_type = try ListBasicType.init(allocator, &uintType, 256, 256);
     defer uintType.deinit();
     defer list_type.deinit();

--- a/packages/ssz/test/int/type/container.zig
+++ b/packages/ssz/test/int/type/container.zig
@@ -8,7 +8,7 @@ const TestCase = @import("common.zig").TypeTestCase;
 test "ContainerType with 2 uints" {
     const allocator = std.testing.allocator;
     const UintType = createUintType(8);
-    const uintType = try UintType.init();
+    const uintType = try UintType.init(null);
     defer uintType.deinit();
 
     const SszType = struct {
@@ -20,7 +20,7 @@ test "ContainerType with 2 uints" {
     var containerType = try ContainerType.init(allocator, SszType{
         .a = uintType,
         .b = uintType,
-    });
+    }, null);
     defer containerType.deinit();
 
     const testCases = [_]TestCase{
@@ -56,7 +56,7 @@ test "ContainerType with 2 uints" {
 test "ContainerType with ListBasicType(uint64, 128) and uint64" {
     const allocator = std.testing.allocator;
     const UintType = createUintType(8);
-    var uintType = try UintType.init();
+    var uintType = try UintType.init(null);
     defer uintType.deinit();
 
     const ListBasicType = createListBasicType(UintType);
@@ -72,7 +72,7 @@ test "ContainerType with ListBasicType(uint64, 128) and uint64" {
     var containerType = try ContainerType.init(allocator, SszType{
         .a = listBasicType,
         .b = uintType,
-    });
+    }, null);
     defer containerType.deinit();
 
     const testCases = [_]TestCase{

--- a/packages/ssz/test/int/type/list_basic.zig
+++ b/packages/ssz/test/int/type/list_basic.zig
@@ -31,7 +31,7 @@ test "valid test for ListBasicType" {
     const UintType = createUintType(8);
     // TODO
     const ListBasicType = createListBasicType(UintType);
-    var uintType = try UintType.init();
+    var uintType = try UintType.init(null);
     var listType = try ListBasicType.init(allocator, &uintType, 128, 128);
     defer uintType.deinit();
     defer listType.deinit();

--- a/packages/ssz/test/int/type/list_composite.zig
+++ b/packages/ssz/test/int/type/list_composite.zig
@@ -62,7 +62,7 @@ test "ListCompositeType - element type Container" {
 
     const allocator = std.testing.allocator;
     const UintType = createUintType(8);
-    const uintType = try UintType.init();
+    const uintType = try UintType.init(null);
     defer uintType.deinit();
 
     const SszType = struct {
@@ -74,7 +74,7 @@ test "ListCompositeType - element type Container" {
     var containerType = try ContainerType.init(allocator, SszType{
         .a = uintType,
         .b = uintType,
-    });
+    }, null);
     defer containerType.deinit();
 
     const ListCompositeType = createListCompositeType(ContainerType);
@@ -108,7 +108,7 @@ test "ListCompositeType - element type ListBasicType" {
 
     const allocator = std.testing.allocator;
     const UintType = createUintType(2);
-    var u16Type = try UintType.init();
+    var u16Type = try UintType.init(null);
     defer u16Type.deinit();
 
     const ListBasicType = createListBasicType(UintType);

--- a/packages/ssz/test/int/type/vector_basic.zig
+++ b/packages/ssz/test/int/type/vector_basic.zig
@@ -26,7 +26,7 @@ test "valid test for VectorBasicType" {
     // uint of 8 bytes = u64
     const UintType = createUintType(8);
     const VectorBasicType = createVectorBasicType(UintType);
-    var uintType = try UintType.init();
+    var uintType = try UintType.init(null);
     var vectorType = try VectorBasicType.init(allocator, &uintType, 8);
     defer uintType.deinit();
     defer vectorType.deinit();

--- a/packages/ssz/test/int/type/vector_composite.zig
+++ b/packages/ssz/test/int/type/vector_composite.zig
@@ -53,7 +53,7 @@ test "VectorCompositeType of Container" {
 
     const allocator = std.testing.allocator;
     const UintType = createUintType(8);
-    const uintType = try UintType.init();
+    const uintType = try UintType.init(null);
     defer uintType.deinit();
 
     const SszType = struct {
@@ -65,7 +65,7 @@ test "VectorCompositeType of Container" {
     var containerType = try ContainerType.init(allocator, SszType{
         .a = uintType,
         .b = uintType,
-    });
+    }, null);
     defer containerType.deinit();
 
     const VectorCompositeType = createVectorCompositeType(ContainerType);


### PR DESCRIPTION
**Motivation**
- ViewDU with tree backed data structure works really well in lodestar, we want to implement it in Zig, see https://github.com/ChainSafe/ssz/tree/master/packages/ssz/src/viewDU


**Description**
- work in progress to implement ViewDU for Container
- right now there is no `get()` `set()` or `defineProperty` equivalent way in Zig
- the only way I found is to use inner struct for each field in a container
- also all generated fields are moved 1 level down through `.fields`
- so it requires `.fields.a.get()` or `.fields.a.set()` to get or set field `a`, this is not nice

```zig
    const viewdu_result = try containerType1.deserializeToViewDU(serialized_bytes);
    defer viewdu_result.deinit();
    const viewdu = viewdu_result.value;

    var a_view = try viewdu.fields.a.get();
    try expect(try a_view.fields.x.get() == obj.a.x);
    try expect(try a_view.fields.y.get() == obj.a.y);

    var b_view = try viewdu.fields.b.get();
    try expect(try b_view.fields.x.get() == obj.b.x);
    try expect(try b_view.fields.y.get() == obj.b.y);

    const viewdu_result_2 = try viewdu.clone();
    defer viewdu_result_2.deinit();

    a_view = try viewdu_result_2.value.fields.a.get();
    try expect(try a_view.fields.x.get() == obj.a.x);
    try expect(try a_view.fields.y.get() == obj.a.y);

    b_view = try viewdu_result_2.value.fields.b.get();
    try expect(try b_view.fields.x.get() == obj.b.x);
    try expect(try b_view.fields.y.get() == obj.b.y);
```

- but there is a work around way by wrapping the generated ViewDU with new methods, or we can redefining the generated struct as well (more hacky)

```zig
// better way, use ptrCast to provide better DX
    const WrappedViewDU = struct {
        viewdu_result: ContainerType1.getViewDUResultType(),

        pub fn clone(self: *const @This()) !@This() {
            const cloned = try self.viewdu_result.value.clone();
            return .{
                .viewdu_result = cloned,
            };
        }

        pub fn deinit(self: *const @This()) void {
            self.viewdu_result.deinit();
        }

        pub fn getA(self: *const @This()) !ContainerType0.getViewDUType() {
            return try self.viewdu_result.value.fields.a.get();
        }

        pub fn getB(self: *const @This()) !ContainerType0.getViewDUType() {
            return try self.viewdu_result.value.fields.b.get();
        }

        pub fn getAX(self: *const @This()) !u64 {
            const a_viewdu = try self.getA();
            return try a_viewdu.fields.x.get();
        }

        pub fn getAY(self: *const @This()) !u64 {
            const a_viewdu = try self.getA();
            return try a_viewdu.fields.y.get();
        }

        pub fn getBX(self: *const @This()) !u64 {
            const b_viewdu = try self.getB();
            return try b_viewdu.fields.x.get();
        }

        pub fn getBY(self: *const @This()) !u64 {
            const b_viewdu = try self.getB();
            return try b_viewdu.fields.y.get();
        }
    };

    const wrapped_viewdu: WrappedViewDU = .{ .viewdu_result = viewdu_result };
    // TODO: double deinit() causes segmentation fault
    // defer wrapped_viewdu.deinit();
    try expect(try wrapped_viewdu.getAX() == obj.a.x);
    try expect(try wrapped_viewdu.getAY() == obj.a.y);
    try expect(try wrapped_viewdu.getBX() == obj.b.x);
    try expect(try wrapped_viewdu.getBY() == obj.b.y);

    const wrapped_viewdu_2 = try wrapped_viewdu.clone();
    defer wrapped_viewdu_2.deinit();

    try expect(try wrapped_viewdu_2.getAX() == obj.a.x);
    try expect(try wrapped_viewdu_2.getAY() == obj.a.y);
    try expect(try wrapped_viewdu_2.getBX() == obj.b.x);
    try expect(try wrapped_viewdu_2.getBY() == obj.b.y);

    try pool.unref(viewdu.root_node);
```