### PR TITLE
fix: unit test TreeView

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
+        with:
+          version: "0.14.0"
 
       - name: Unit tests
         run: |
@@ -35,6 +37,8 @@ jobs:
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
+        with:
+          version: "0.14.0"
 
       - name: Cache spec tests
         id: spec-tests
@@ -46,7 +50,7 @@ jobs:
       - name: Download spec tests
         run: |
           zig build run:download_spec_tests
-      
+
       - name: Write generic spec tests
         run: |
           zig build run:write_generic_spec_tests
@@ -54,15 +58,15 @@ jobs:
       - name: Write static spec tests
         run: |
           zig build run:write_static_spec_tests
-      
+
       - name: Run generic spec tests
         run: |
           zig build test:generic_spec_tests
-      
+
       - name: Run minimal static spec tests
         run: |
           zig build test:static_spec_tests -Dpreset=minimal
-      
+
       - name: Run mainnet static spec tests
         run: |
           zig build test:static_spec_tests -Dpreset=mainnet

--- a/build.zig
+++ b/build.zig
@@ -519,6 +519,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     b.modules.put(b.dupe("int"), module_int) catch @panic("OOM");
+    module_int.addImport("persistent_merkle_tree", module_persistent_merkle_tree);
 
     const test_int = b.addTest(.{
         .name = "int",

--- a/src/persistent_merkle_tree/gindex.zig
+++ b/src/persistent_merkle_tree/gindex.zig
@@ -97,7 +97,7 @@ pub const Gindex = enum(GindexUint) {
 
     pub fn sortAsc(items: []Gindex) void {
         std.sort.pdq(Gindex, items, {}, struct {
-            pub fn lessThan(a: Gindex, b: Gindex) bool {
+            pub fn lessThan(_: void, a: Gindex, b: Gindex) bool {
                 return @intFromEnum(a) < @intFromEnum(b);
             }
         }.lessThan);

--- a/src/persistent_merkle_tree/node_bench.zig
+++ b/src/persistent_merkle_tree/node_bench.zig
@@ -116,5 +116,5 @@ fn createTree(allocator: std.mem.Allocator, depth: u6, length: usize) !Node.Id {
     for (0..leaves.len) |i| {
         leaves[i] = try pool.createLeafFromUint(i, false);
     }
-    return try Node.fillWithContents(&pool, leaves, depth);
+    return try Node.fillWithContents(&pool, leaves, depth, true);
 }

--- a/src/ssz/root.zig
+++ b/src/ssz/root.zig
@@ -3,3 +3,4 @@ const testing = std.testing;
 
 pub usingnamespace @import("type/root.zig");
 pub usingnamespace @import("hasher.zig");
+pub usingnamespace @import("tree_view.zig");

--- a/src/ssz/tree_view.zig
+++ b/src/ssz/tree_view.zig
@@ -2,7 +2,63 @@ const std = @import("std");
 const Depth = @import("hashing").Depth;
 const Node = @import("persistent_merkle_tree").Node;
 const Gindex = @import("persistent_merkle_tree").Gindex;
-const isBasicType = @import("type_kind.zig").isBasicType;
+const isBasicType = @import("type/type_kind.zig").isBasicType;
+
+pub const Data = struct {
+    root: Node.Id,
+
+    /// cached nodes for faster access of already-visited children
+    children_nodes: std.AutoHashMap(Gindex, Node.Id),
+
+    /// cached data for faster access of already-visited children
+    children_data: std.AutoHashMap(Gindex, Data),
+
+    /// whether the corresponding child node/data has changed since the last update of the root
+    changed: std.AutoArrayHashMap(Gindex, void),
+
+    pub fn init(allocator: std.mem.Allocator, pool: *Node.Pool, root: Node.Id) !Data {
+        try pool.ref(root);
+        return Data{
+            .root = root,
+            .children_nodes = std.AutoHashMap(Gindex, Node.Id).init(allocator),
+            .children_data = std.AutoHashMap(Gindex, Data).init(allocator),
+            .changed = std.AutoArrayHashMap(Gindex, void).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *Data, pool: *Node.Pool) void {
+        pool.unref(self.root);
+        self.children_nodes.deinit();
+        self.children_data.deinit();
+        self.changed.deinit();
+    }
+
+    pub fn commit(self: *Data, allocator: std.mem.Allocator, pool: *Node.Pool) !void {
+        const nodes = try self.allocator.alloc(Node.Id, self.data.changed.count());
+        defer self.allocator.free(nodes);
+
+        const gindices = self.data.changed.keys();
+        Gindex.sortAsc(gindices);
+
+        for (gindices, 0..) |gindex, i| {
+            if (self.data.children_data.get(gindex)) |child_data| {
+                try child_data.commit(allocator);
+                nodes[i] = child_data.root;
+            } else if (self.data.children_nodes.get(gindex)) |child_node| {
+                nodes[i] = child_node;
+            } else {
+                return error.ChildNotFound;
+            }
+        }
+
+        const new_root = try self.data.root.setNodes(self.pool, gindices, nodes);
+        try pool.ref(new_root);
+        pool.unref(self.root);
+        self.root = new_root;
+
+        self.changed.clearRetainingCapacity();
+    }
+};
 
 pub fn TreeView(comptime ST: type) type {
     comptime {
@@ -14,71 +70,15 @@ pub fn TreeView(comptime ST: type) type {
         allocator: std.mem.Allocator,
         pool: *Node.Pool,
         data: Data,
-
-        pub const Data = struct {
-            root: Node.Id,
-
-            /// cached nodes for faster access of already-visited children
-            children_nodes: std.AutoHashMap(Gindex, Node.Id),
-
-            /// cached data for faster access of already-visited children
-            children_data: std.AutoHashMap(Gindex, Data),
-
-            /// whether the corresponding child node/data has changed since the last update of the root
-            changed: std.AutoArrayHashMap(Gindex, void),
-
-            pub fn init(allocator: std.mem.Allocator, pool: *Node.Pool, root: Node.Id) Data {
-                try pool.ref(root);
-                return Data{
-                    .root = root,
-                    .children_nodes = std.AutoHashMap(Gindex, Node.Id).init(allocator),
-                    .children_data = std.AutoHashMap(Gindex, Data).init(allocator),
-                    .changed = std.AutoArrayHashMap(Gindex, void).init(allocator),
-                };
-            }
-
-            pub fn deinit(self: *Data, pool: *Node.Pool) void {
-                pool.unref(self.root);
-                self.children_nodes.deinit();
-                self.children_data.deinit();
-                self.changed.deinit();
-            }
-
-            pub fn commit(self: *Data, allocator: std.mem.Allocator, pool: *Node.Pool) !void {
-                const nodes = try self.allocator.alloc(Node.Id, self.data.changed.count());
-                defer self.allocator.free(nodes);
-
-                const gindices = self.data.changed.keys();
-                Gindex.sortAsc(gindices);
-
-                for (gindices, 0..) |gindex, i| {
-                    if (self.data.children_data.get(gindex)) |child_data| {
-                        try child_data.commit(allocator);
-                        nodes[i] = child_data.root;
-                    } else if (self.data.children_nodes.get(gindex)) |child_node| {
-                        nodes[i] = child_node;
-                    } else {
-                        return error.ChildNotFound;
-                    }
-                }
-
-                const new_root = try self.data.root.setNodes(self.pool, gindices, nodes);
-                try pool.ref(new_root);
-                pool.unref(self.root);
-                self.root = new_root;
-
-                self.changed.clearRetainingCapacity();
-            }
-        };
+        pub const SszType: type = ST;
 
         const Self = @This();
 
         pub fn init(allocator: std.mem.Allocator, pool: *Node.Pool, root: Node.Id) !Self {
-            switch (ST.kind) {}
             return Self{
                 .allocator = allocator,
                 .pool = pool,
-                .data = Data.init(allocator, pool, root),
+                .data = try Data.init(allocator, pool, root),
             };
         }
 
@@ -111,7 +111,7 @@ pub fn TreeView(comptime ST: type) type {
                 return gop.value_ptr.*;
             }
             const child_node = try self.getChildNode(gindex);
-            const child_data = try Data.init(self.allocator, child_node);
+            const child_data = try Data.init(self.allocator, self.pool, child_node);
             gop.value_ptr.* = child_data;
             return child_data;
         }
@@ -171,7 +171,7 @@ pub fn TreeView(comptime ST: type) type {
         }
 
         pub fn Field(comptime field_name: []const u8) type {
-            const ChildST = @field(ST.fields, field_name).type;
+            const ChildST = ST.getFieldType(field_name);
             if (comptime isBasicType(ChildST)) {
                 return ChildST.Type;
             } else {
@@ -179,12 +179,12 @@ pub fn TreeView(comptime ST: type) type {
             }
         }
 
-        pub fn getField(self: *Self, comptime field_name: []const u8) Field(ST, field_name) {
+        pub fn getField(self: *Self, comptime field_name: []const u8) !Field(field_name) {
             if (comptime ST.kind != .container) {
                 @compileError("getField can only be used with container types");
             }
-            const field_index = ST.getFieldIndex(field_name);
-            const ChildST = @field(ST.fields, field_name).type;
+            const field_index = comptime ST.getFieldIndex(field_name);
+            const ChildST = ST.getFieldType(field_name);
             const child_gindex = Gindex.fromDepth(ST.chunk_depth, field_index);
             if (comptime isBasicType(ChildST)) {
                 var value: ChildST.Type = undefined;
@@ -195,7 +195,7 @@ pub fn TreeView(comptime ST: type) type {
                 const child_data = try self.getChildData(child_gindex);
 
                 // TODO only update changed if the subview is mutable
-                self.data.changed.put(child_gindex, void);
+                try self.data.changed.put(child_gindex, {});
 
                 return TreeView(ChildST){
                     .allocator = self.allocator,
@@ -205,14 +205,14 @@ pub fn TreeView(comptime ST: type) type {
             }
         }
 
-        pub fn setField(self: *Self, comptime field_name: []const u8, value: Field(ST, field_name)) !void {
+        pub fn setField(self: *Self, comptime field_name: []const u8, value: Field(field_name)) !void {
             if (comptime ST.kind != .container) {
                 @compileError("setField can only be used with container types");
             }
-            const field_index = ST.getFieldIndex(field_name);
-            const ChildST = @field(ST.fields, field_name).type;
+            const field_index = comptime ST.getFieldIndex(field_name);
+            const ChildST = ST.getFieldType(field_name);
             const child_gindex = Gindex.fromDepth(ST.chunk_depth, field_index);
-            try self.data.changed.put(child_gindex, void);
+            try self.data.changed.put(child_gindex, {});
             if (comptime isBasicType(ChildST)) {
                 try self.data.children_nodes.put(
                     child_gindex,

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -194,6 +194,16 @@ pub fn FixedContainerType(comptime ST: type) type {
             }
         }
 
+        pub fn getFieldType(comptime name: []const u8) type {
+            inline for (fields) |field| {
+                if (std.mem.eql(u8, name, field.name)) {
+                    return field.type;
+                }
+            } else {
+                @compileError("field does not exist");
+            }
+        }
+
         pub fn getFieldGindex(comptime name: []const u8) Gindex {
             const field_index = getFieldIndex(name);
             return comptime Gindex.fromDepth(chunk_depth, field_index);
@@ -352,6 +362,16 @@ pub fn VariableContainerType(comptime ST: type) type {
             inline for (fields, 0..) |field, i| {
                 if (std.mem.eql(u8, name, field.name)) {
                     return i;
+                }
+            } else {
+                @compileError("field does not exist");
+            }
+        }
+
+        pub fn getFieldType(comptime name: []const u8) type {
+            inline for (fields) |field| {
+                if (std.mem.eql(u8, name, field.name)) {
+                    return field.type;
                 }
             } else {
                 @compileError("field does not exist");

--- a/test/int/root.zig
+++ b/test/int/root.zig
@@ -8,6 +8,7 @@ const list_composite = @import("type/list_composite.zig");
 const bit_vector = @import("type/bit_vector.zig");
 const bit_list = @import("type/bit_list.zig");
 const byte_list = @import("type/byte_list.zig");
+const tree_view = @import("type/tree_view.zig");
 
 test {
     testing.refAllDecls(list_basic);
@@ -18,4 +19,5 @@ test {
     testing.refAllDecls(bit_vector);
     testing.refAllDecls(bit_list);
     testing.refAllDecls(byte_list);
+    testing.refAllDecls(tree_view);
 }

--- a/test/int/type/tree_view.zig
+++ b/test/int/type/tree_view.zig
@@ -43,4 +43,23 @@ test "TreeView" {
     root_view = try view.getField("root");
     try RootView.SszType.tree.toValue(root_view.data.root, &pool, root[0..]);
     try std.testing.expectEqualSlices(u8, ([_]u8{2} ** 32)[0..], root[0..]);
+
+    // commit and check hash_tree_root
+    // TODO: fix setNodes() api
+    // try view.commit();
+    // var htr_from_value: [32]u8 = undefined;
+    // const expected_checkpoint: Checkpoint.Type = .{
+    //     .epoch = 100,
+    //     .root = [_]u8{2} ** 32,
+    // };
+    // try Checkpoint.hashTreeRoot(&expected_checkpoint, &htr_from_value);
+
+    // var htr_from_tree: [32]u8 = undefined;
+    // try view.hashTreeRoot(&htr_from_tree);
+
+    // try std.testing.expectEqualSlices(
+    //     u8,
+    //     &htr_from_value,
+    //     &htr_from_tree,
+    // );
 }

--- a/test/int/type/tree_view.zig
+++ b/test/int/type/tree_view.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const ssz = @import("ssz");
+
+const Checkpoint = ssz.FixedContainerType(struct {
+    epoch: ssz.UintType(64),
+    root: ssz.ByteVectorType(32),
+});
+
+test "TreeView" {
+    const Node = @import("persistent_merkle_tree").Node;
+    var pool = try Node.Pool.init(std.testing.allocator, 1000);
+    defer pool.deinit();
+    const checkpoint: Checkpoint.Type = .{
+        .epoch = 42,
+        .root = [_]u8{1} ** 32,
+    };
+
+    const root_node = try Checkpoint.tree.fromValue(&pool, &checkpoint);
+    var view = try ssz.TreeView(Checkpoint).init(std.testing.allocator, &pool, root_node);
+    defer view.deinit();
+
+    // get field "epoch"
+    try std.testing.expectEqual(42, try view.getField("epoch"));
+
+    // get field "root"
+    var root_view = try view.getField("root");
+    var root = [_]u8{0} ** 32;
+    const RootView = ssz.TreeView(Checkpoint).Field("root");
+    try RootView.SszType.tree.toValue(root_view.data.root, &pool, root[0..]);
+    try std.testing.expectEqualSlices(u8, ([_]u8{1} ** 32)[0..], root[0..]);
+
+    // modify field "epoch"
+    try view.setField("epoch", 100);
+    try std.testing.expectEqual(100, try view.getField("epoch"));
+
+    // modify field "root"
+    var new_root = [_]u8{2} ** 32;
+    const new_root_node = try RootView.SszType.tree.fromValue(&pool, &new_root);
+    const new_root_view = try RootView.init(std.testing.allocator, &pool, new_root_node);
+    try view.setField("root", new_root_view);
+
+    // confirm "root" has been modified
+    root_view = try view.getField("root");
+    try RootView.SszType.tree.toValue(root_view.data.root, &pool, root[0..]);
+    try std.testing.expectEqualSlices(u8, ([_]u8{2} ** 32)[0..], root[0..]);
+}


### PR DESCRIPTION
**Motivation**
- bring TreeView in Readme to unit test

**Description**
- new `tree_view.zig` test under `test/int/type`, run it via `zig build test:int`
- move `TreeView.Data` to a separate struct because it's common for all TreeView types, otherwise get error: `error: expected type 'tree_view.TreeView(type.byte_vector.ByteVectorType(32)).Data', found 'tree_view.TreeView(type.container.FixedContainerType(type.tree_view.Checkpoint__struct_30115)).Data'`
- commit() does not work due to `setNodes()`, can look into it in another PR