### PR TITLE
fix: use heap to download spec test

### DIFF
--- a/test/spec/download_spec_tests.zig
+++ b/test/spec/download_spec_tests.zig
@@ -110,11 +110,12 @@ fn download_spec_test_archive(
 
     std.log.info("writing response to disk - {s}", .{filename});
 
-    var buf: [16 * 1024000]u8 = undefined;
+    var buf = try allocator.alloc(u8, 16 * 1024000);
+    defer allocator.free(buf);
     var reader = req.reader();
     var bytes_count: usize = 0;
     while (true) {
-        const read_bytes = try reader.readAll(&buf);
+        const read_bytes = try reader.readAll(buf);
         try file.writeAll(buf[0..read_bytes]);
         bytes_count += read_bytes;
         if (read_bytes != buf.len) {


### PR DESCRIPTION
Currently, we try to allocate 16MB in the stack to a buffer when downloading spec test files.

When running on Mac, I got `illegal hardware instruction` because Mac's default stack size is 8MB and there is no way to reliably override this via `ulimit`.

Stack is often limited in size and we should be cautious when allocating large memory (quick google search says >1KB)on it.