### PR TITLE
fix: list type allocating more memory than necessary in `deserializeFromJson`

### DIFF
--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -100,8 +100,7 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int) type {
                     else => {},
                 }
 
-                try out.ensureUnusedCapacity(allocator, 1);
-                out.expandToCapacity();
+                _ = try out.addOne(allocator);
                 try Element.deserializeFromJson(source, &out.items[i]);
             }
             return error.invalidLength;
@@ -470,8 +469,7 @@ pub fn VariableListType(comptime ST: type, comptime _limit: comptime_int) type {
                     else => {},
                 }
 
-                try out.ensureUnusedCapacity(allocator, 1);
-                out.expandToCapacity();
+                _ = try out.addOne(allocator);
                 try Element.deserializeFromJson(allocator, source, &out.items[i]);
             }
             return error.invalidLength;


### PR DESCRIPTION
`ensureUnusedCapacity(allocator, 1)` will try to ensure `capacity` can store `items.len + 1`. If insufficient, it will call `growCapacity()`, which increases `capacity` by at least 50%.

If we call `expandToCapacity()` afterwards, we increase `items.len` to match `capacity`.

If we do the following code iteratively, we increase capacity and len by at least 50% in each iteration. 
```
                try out.ensureUnusedCapacity(allocator, 1);
                out.expandToCapacity();
```

We should just do `addOne` to ensure `ArrayList` can store one more item than it currently stores