### PR TITLE
fix: avoid child field copy using @field

### DIFF
--- a/src/ssz/hasher.zig
+++ b/src/ssz/hasher.zig
@@ -98,8 +98,8 @@ pub fn Hasher(comptime ST: type) type {
                     .container => {
                         @memset(scratch.chunks.items, [_]u8{0} ** 32);
                         inline for (ST.fields, 0..) |field, i| {
-                            const field_value = @field(value, field.name);
-                            try Hasher(field.type).hash(&scratch.children.?[i], &field_value, &scratch.chunks.items[i]);
+                            const field_value_ptr = &@field(value, field.name);
+                            try Hasher(field.type).hash(&scratch.children.?[i], field_value_ptr, &scratch.chunks.items[i]);
                         }
                         try h.merkleize(@ptrCast(scratch.chunks.items), ST.chunk_depth, out);
                     },

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -76,8 +76,8 @@ pub fn FixedContainerType(comptime ST: type) type {
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {
             var i: usize = 0;
             inline for (fields) |field| {
-                const field_value = @field(value, field.name);
-                i += field.type.serializeIntoBytes(&field_value, out[i..]);
+                const field_value_ptr = &@field(value, field.name);
+                i += field.type.serializeIntoBytes(field_value_ptr, out[i..]);
             }
             return i;
         }
@@ -138,8 +138,8 @@ pub fn FixedContainerType(comptime ST: type) type {
             pub fn serializeIntoBytes(value: Node.Id, pool: *Node.Pool, out: []u8) !usize {
                 var i: usize = 0;
                 inline for (fields) |field| {
-                    const field_value = @field(value, field.name);
-                    i += try field.type.tree.serializeIntoBytes(field_value, pool, out[i..]);
+                    const field_value_ptr = &@field(value, field.name);
+                    i += try field.type.tree.serializeIntoBytes(field_value_ptr, pool, out[i..]);
                 }
                 return i;
             }


### PR DESCRIPTION
**Motivation**
- avoid unnecessary value copy through `@field()` util

**Description**
- use `&@field()` instead