### PR TITLE
fix: last byte check when deserializing json into bit vector

### DIFF
--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -179,7 +179,7 @@ pub fn BitVectorType(comptime _length: comptime_int) type {
                 return error.invalidLength;
             }
             // ensure trailing zeros for non-byte-aligned lengths
-            if (length % 8 != 0 and @clz(out.data[fixed_size - 1]) >= @clz(@as(u8, length / 8))) {
+            if (length % 8 != 0 and @clz(out.data[fixed_size - 1]) < 8 - length % 8) {
                 return error.trailingData;
             }
         }


### PR DESCRIPTION
After deserializing json into bit vector, we need to ensure the last byte of the bit vector to have at least `8 - length % 8` leading zeros, but in currency code we are checking the opposite.

Also `@clz(@as(u8, length / 8))` seems wrong. Its value is 0 when length is between 0 and 7, 1 when length is between 8 and 15 etc which doesn't make too much sense.