### PR TITLE
deps: remove bun-ffi generation from `zbuild.zon`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -65,13 +65,6 @@ pub fn build(b: *std.Build) void {
     });
     b.modules.put(b.dupe("consensus_types"), module_consensus_types) catch @panic("OOM");
 
-    const module_bun_ffi = b.createModule(.{
-        .root_source_file = b.path("src/bun_ffi/root.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    b.modules.put(b.dupe("bun_ffi"), module_bun_ffi) catch @panic("OOM");
-
     const module_download_spec_tests = b.createModule(.{
         .root_source_file = b.path("test/spec/download_spec_tests.zig"),
         .target = target,
@@ -85,6 +78,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_download_spec_tests = b.addInstallArtifact(exe_download_spec_tests, .{});
+
     const tls_install_exe_download_spec_tests = b.step("build-exe:download_spec_tests", "Install the download_spec_tests executable");
     tls_install_exe_download_spec_tests.dependOn(&install_exe_download_spec_tests.step);
     b.getInstallStep().dependOn(&install_exe_download_spec_tests.step);
@@ -107,6 +101,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_write_generic_spec_tests = b.addInstallArtifact(exe_write_generic_spec_tests, .{});
+
     const tls_install_exe_write_generic_spec_tests = b.step("build-exe:write_generic_spec_tests", "Install the write_generic_spec_tests executable");
     tls_install_exe_write_generic_spec_tests.dependOn(&install_exe_write_generic_spec_tests.step);
     b.getInstallStep().dependOn(&install_exe_write_generic_spec_tests.step);
@@ -129,6 +124,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_write_static_spec_tests = b.addInstallArtifact(exe_write_static_spec_tests, .{});
+
     const tls_install_exe_write_static_spec_tests = b.step("build-exe:write_static_spec_tests", "Install the write_static_spec_tests executable");
     tls_install_exe_write_static_spec_tests.dependOn(&install_exe_write_static_spec_tests.step);
     b.getInstallStep().dependOn(&install_exe_write_static_spec_tests.step);
@@ -151,6 +147,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_attestation = b.addInstallArtifact(exe_bench_attestation, .{});
+
     const tls_install_exe_bench_attestation = b.step("build-exe:bench_attestation", "Install the bench_attestation executable");
     tls_install_exe_bench_attestation.dependOn(&install_exe_bench_attestation.step);
     b.getInstallStep().dependOn(&install_exe_bench_attestation.step);
@@ -173,6 +170,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_block = b.addInstallArtifact(exe_bench_block, .{});
+
     const tls_install_exe_bench_block = b.step("build-exe:bench_block", "Install the bench_block executable");
     tls_install_exe_bench_block.dependOn(&install_exe_bench_block.step);
     b.getInstallStep().dependOn(&install_exe_bench_block.step);
@@ -195,6 +193,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_state = b.addInstallArtifact(exe_bench_state, .{});
+
     const tls_install_exe_bench_state = b.step("build-exe:bench_state", "Install the bench_state executable");
     tls_install_exe_bench_state.dependOn(&install_exe_bench_state.step);
     b.getInstallStep().dependOn(&install_exe_bench_state.step);
@@ -217,6 +216,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_gindex = b.addInstallArtifact(exe_bench_gindex, .{});
+
     const tls_install_exe_bench_gindex = b.step("build-exe:bench_gindex", "Install the bench_gindex executable");
     tls_install_exe_bench_gindex.dependOn(&install_exe_bench_gindex.step);
     b.getInstallStep().dependOn(&install_exe_bench_gindex.step);
@@ -239,6 +239,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_node = b.addInstallArtifact(exe_bench_node, .{});
+
     const tls_install_exe_bench_node = b.step("build-exe:bench_node", "Install the bench_node executable");
     tls_install_exe_bench_node.dependOn(&install_exe_bench_node.step);
     b.getInstallStep().dependOn(&install_exe_bench_node.step);
@@ -261,6 +262,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_hashing = b.addInstallArtifact(exe_bench_hashing, .{});
+
     const tls_install_exe_bench_hashing = b.step("build-exe:bench_hashing", "Install the bench_hashing executable");
     tls_install_exe_bench_hashing.dependOn(&install_exe_bench_hashing.step);
     b.getInstallStep().dependOn(&install_exe_bench_hashing.step);
@@ -283,6 +285,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_lib_types = b.addInstallArtifact(lib_types, .{});
+
     const tls_install_lib_types = b.step("build-lib:types", "Install the types library");
     tls_install_lib_types.dependOn(&install_lib_types.step);
     b.getInstallStep().dependOn(&install_lib_types.step);
@@ -358,20 +361,6 @@ pub fn build(b: *std.Build) void {
     const tls_run_test_consensus_types = b.step("test:consensus_types", "Run the consensus_types test");
     tls_run_test_consensus_types.dependOn(&run_test_consensus_types.step);
     tls_run_test.dependOn(&run_test_consensus_types.step);
-
-    const test_bun_ffi = b.addTest(.{
-        .name = "bun_ffi",
-        .root_module = module_bun_ffi,
-        .filters = &[_][]const u8{},
-    });
-    const install_test_bun_ffi = b.addInstallArtifact(test_bun_ffi, .{});
-    const tls_install_test_bun_ffi = b.step("build-test:bun_ffi", "Install the bun_ffi test");
-    tls_install_test_bun_ffi.dependOn(&install_test_bun_ffi.step);
-
-    const run_test_bun_ffi = b.addRunArtifact(test_bun_ffi);
-    const tls_run_test_bun_ffi = b.step("test:bun_ffi", "Run the bun_ffi test");
-    tls_run_test_bun_ffi.dependOn(&run_test_bun_ffi.step);
-    tls_run_test.dependOn(&run_test_bun_ffi.step);
 
     const test_download_spec_tests = b.addTest(.{
         .name = "download_spec_tests",
@@ -592,11 +581,6 @@ pub fn build(b: *std.Build) void {
 
     module_consensus_types.addImport("build_options", options_module_build_options);
     module_consensus_types.addImport("ssz", module_ssz);
-
-    module_bun_ffi.addImport("build_options", options_module_build_options);
-    module_bun_ffi.addImport("persistent_merkle_tree", module_persistent_merkle_tree);
-    module_bun_ffi.addImport("ssz", module_ssz);
-    module_bun_ffi.addImport("consensus_types", module_consensus_types);
 
     module_download_spec_tests.addImport("spec_test_options", options_module_spec_test_options);
 

--- a/build.zig
+++ b/build.zig
@@ -78,6 +78,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_download_spec_tests = b.addInstallArtifact(exe_download_spec_tests, .{});
+
     const tls_install_exe_download_spec_tests = b.step("build-exe:download_spec_tests", "Install the download_spec_tests executable");
     tls_install_exe_download_spec_tests.dependOn(&install_exe_download_spec_tests.step);
     b.getInstallStep().dependOn(&install_exe_download_spec_tests.step);
@@ -100,6 +101,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_write_generic_spec_tests = b.addInstallArtifact(exe_write_generic_spec_tests, .{});
+
     const tls_install_exe_write_generic_spec_tests = b.step("build-exe:write_generic_spec_tests", "Install the write_generic_spec_tests executable");
     tls_install_exe_write_generic_spec_tests.dependOn(&install_exe_write_generic_spec_tests.step);
     b.getInstallStep().dependOn(&install_exe_write_generic_spec_tests.step);
@@ -122,6 +124,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_write_static_spec_tests = b.addInstallArtifact(exe_write_static_spec_tests, .{});
+
     const tls_install_exe_write_static_spec_tests = b.step("build-exe:write_static_spec_tests", "Install the write_static_spec_tests executable");
     tls_install_exe_write_static_spec_tests.dependOn(&install_exe_write_static_spec_tests.step);
     b.getInstallStep().dependOn(&install_exe_write_static_spec_tests.step);
@@ -144,6 +147,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_attestation = b.addInstallArtifact(exe_bench_attestation, .{});
+
     const tls_install_exe_bench_attestation = b.step("build-exe:bench_attestation", "Install the bench_attestation executable");
     tls_install_exe_bench_attestation.dependOn(&install_exe_bench_attestation.step);
     b.getInstallStep().dependOn(&install_exe_bench_attestation.step);
@@ -166,6 +170,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_block = b.addInstallArtifact(exe_bench_block, .{});
+
     const tls_install_exe_bench_block = b.step("build-exe:bench_block", "Install the bench_block executable");
     tls_install_exe_bench_block.dependOn(&install_exe_bench_block.step);
     b.getInstallStep().dependOn(&install_exe_bench_block.step);
@@ -188,6 +193,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_state = b.addInstallArtifact(exe_bench_state, .{});
+
     const tls_install_exe_bench_state = b.step("build-exe:bench_state", "Install the bench_state executable");
     tls_install_exe_bench_state.dependOn(&install_exe_bench_state.step);
     b.getInstallStep().dependOn(&install_exe_bench_state.step);
@@ -210,6 +216,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_gindex = b.addInstallArtifact(exe_bench_gindex, .{});
+
     const tls_install_exe_bench_gindex = b.step("build-exe:bench_gindex", "Install the bench_gindex executable");
     tls_install_exe_bench_gindex.dependOn(&install_exe_bench_gindex.step);
     b.getInstallStep().dependOn(&install_exe_bench_gindex.step);
@@ -232,6 +239,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_node = b.addInstallArtifact(exe_bench_node, .{});
+
     const tls_install_exe_bench_node = b.step("build-exe:bench_node", "Install the bench_node executable");
     tls_install_exe_bench_node.dependOn(&install_exe_bench_node.step);
     b.getInstallStep().dependOn(&install_exe_bench_node.step);
@@ -254,6 +262,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const install_exe_bench_hashing = b.addInstallArtifact(exe_bench_hashing, .{});
+
     const tls_install_exe_bench_hashing = b.step("build-exe:bench_hashing", "Install the bench_hashing executable");
     tls_install_exe_bench_hashing.dependOn(&install_exe_bench_hashing.step);
     b.getInstallStep().dependOn(&install_exe_bench_hashing.step);
@@ -268,7 +277,7 @@ pub fn build(b: *std.Build) void {
     const test_hex = b.addTest(.{
         .name = "hex",
         .root_module = module_hex,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_hex = b.addInstallArtifact(test_hex, .{});
     const tls_install_test_hex = b.step("build-test:hex", "Install the hex test");
@@ -282,7 +291,7 @@ pub fn build(b: *std.Build) void {
     const test_hashing = b.addTest(.{
         .name = "hashing",
         .root_module = module_hashing,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_hashing = b.addInstallArtifact(test_hashing, .{});
     const tls_install_test_hashing = b.step("build-test:hashing", "Install the hashing test");
@@ -296,7 +305,7 @@ pub fn build(b: *std.Build) void {
     const test_persistent_merkle_tree = b.addTest(.{
         .name = "persistent_merkle_tree",
         .root_module = module_persistent_merkle_tree,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_persistent_merkle_tree = b.addInstallArtifact(test_persistent_merkle_tree, .{});
     const tls_install_test_persistent_merkle_tree = b.step("build-test:persistent_merkle_tree", "Install the persistent_merkle_tree test");
@@ -310,7 +319,7 @@ pub fn build(b: *std.Build) void {
     const test_ssz = b.addTest(.{
         .name = "ssz",
         .root_module = module_ssz,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_ssz = b.addInstallArtifact(test_ssz, .{});
     const tls_install_test_ssz = b.step("build-test:ssz", "Install the ssz test");
@@ -324,7 +333,7 @@ pub fn build(b: *std.Build) void {
     const test_consensus_types = b.addTest(.{
         .name = "consensus_types",
         .root_module = module_consensus_types,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_consensus_types = b.addInstallArtifact(test_consensus_types, .{});
     const tls_install_test_consensus_types = b.step("build-test:consensus_types", "Install the consensus_types test");
@@ -338,7 +347,7 @@ pub fn build(b: *std.Build) void {
     const test_download_spec_tests = b.addTest(.{
         .name = "download_spec_tests",
         .root_module = module_download_spec_tests,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_download_spec_tests = b.addInstallArtifact(test_download_spec_tests, .{});
     const tls_install_test_download_spec_tests = b.step("build-test:download_spec_tests", "Install the download_spec_tests test");
@@ -352,7 +361,7 @@ pub fn build(b: *std.Build) void {
     const test_write_generic_spec_tests = b.addTest(.{
         .name = "write_generic_spec_tests",
         .root_module = module_write_generic_spec_tests,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_write_generic_spec_tests = b.addInstallArtifact(test_write_generic_spec_tests, .{});
     const tls_install_test_write_generic_spec_tests = b.step("build-test:write_generic_spec_tests", "Install the write_generic_spec_tests test");
@@ -366,7 +375,7 @@ pub fn build(b: *std.Build) void {
     const test_write_static_spec_tests = b.addTest(.{
         .name = "write_static_spec_tests",
         .root_module = module_write_static_spec_tests,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_write_static_spec_tests = b.addInstallArtifact(test_write_static_spec_tests, .{});
     const tls_install_test_write_static_spec_tests = b.step("build-test:write_static_spec_tests", "Install the write_static_spec_tests test");
@@ -380,7 +389,7 @@ pub fn build(b: *std.Build) void {
     const test_bench_attestation = b.addTest(.{
         .name = "bench_attestation",
         .root_module = module_bench_attestation,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_bench_attestation = b.addInstallArtifact(test_bench_attestation, .{});
     const tls_install_test_bench_attestation = b.step("build-test:bench_attestation", "Install the bench_attestation test");
@@ -394,7 +403,7 @@ pub fn build(b: *std.Build) void {
     const test_bench_block = b.addTest(.{
         .name = "bench_block",
         .root_module = module_bench_block,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_bench_block = b.addInstallArtifact(test_bench_block, .{});
     const tls_install_test_bench_block = b.step("build-test:bench_block", "Install the bench_block test");
@@ -408,7 +417,7 @@ pub fn build(b: *std.Build) void {
     const test_bench_state = b.addTest(.{
         .name = "bench_state",
         .root_module = module_bench_state,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_bench_state = b.addInstallArtifact(test_bench_state, .{});
     const tls_install_test_bench_state = b.step("build-test:bench_state", "Install the bench_state test");
@@ -422,7 +431,7 @@ pub fn build(b: *std.Build) void {
     const test_bench_gindex = b.addTest(.{
         .name = "bench_gindex",
         .root_module = module_bench_gindex,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_bench_gindex = b.addInstallArtifact(test_bench_gindex, .{});
     const tls_install_test_bench_gindex = b.step("build-test:bench_gindex", "Install the bench_gindex test");
@@ -436,7 +445,7 @@ pub fn build(b: *std.Build) void {
     const test_bench_node = b.addTest(.{
         .name = "bench_node",
         .root_module = module_bench_node,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_bench_node = b.addInstallArtifact(test_bench_node, .{});
     const tls_install_test_bench_node = b.step("build-test:bench_node", "Install the bench_node test");
@@ -450,7 +459,7 @@ pub fn build(b: *std.Build) void {
     const test_bench_hashing = b.addTest(.{
         .name = "bench_hashing",
         .root_module = module_bench_hashing,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_bench_hashing = b.addInstallArtifact(test_bench_hashing, .{});
     const tls_install_test_bench_hashing = b.step("build-test:bench_hashing", "Install the bench_hashing test");
@@ -471,7 +480,7 @@ pub fn build(b: *std.Build) void {
     const test_int = b.addTest(.{
         .name = "int",
         .root_module = module_int,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_int = b.addInstallArtifact(test_int, .{});
     const tls_install_test_int = b.step("build-test:int", "Install the int test");
@@ -492,7 +501,7 @@ pub fn build(b: *std.Build) void {
     const test_generic_spec_tests = b.addTest(.{
         .name = "generic_spec_tests",
         .root_module = module_generic_spec_tests,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_generic_spec_tests = b.addInstallArtifact(test_generic_spec_tests, .{});
     const tls_install_test_generic_spec_tests = b.step("build-test:generic_spec_tests", "Install the generic_spec_tests test");
@@ -513,7 +522,7 @@ pub fn build(b: *std.Build) void {
     const test_static_spec_tests = b.addTest(.{
         .name = "static_spec_tests",
         .root_module = module_static_spec_tests,
-        .filters = &[_][]const u8{  },
+        .filters = &[_][]const u8{},
     });
     const install_test_static_spec_tests = b.addInstallArtifact(test_static_spec_tests, .{});
     const tls_install_test_static_spec_tests = b.step("build-test:static_spec_tests", "Install the static_spec_tests test");
@@ -587,5 +596,4 @@ pub fn build(b: *std.Build) void {
     module_static_spec_tests.addImport("spec_test_options", options_module_spec_test_options);
     module_static_spec_tests.addImport("consensus_types", module_consensus_types);
     module_static_spec_tests.addImport("yaml", dep_yaml.module("yaml"));
-
 }

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -68,10 +68,11 @@
             .root_source_file = "src/consensus_types/root.zig",
             .imports = .{ .build_options, .ssz },
         },
-        .bun_ffi = .{
-            .root_source_file = "src/bun_ffi/root.zig",
-            .imports = .{ .build_options, .persistent_merkle_tree, .ssz, .consensus_types },
-        },
+        //TODO(bing): reintroduce when bun-ffi generation is fixed
+        //.bun_ffi = .{
+        //    .root_source_file = "src/bun_ffi/root.zig",
+        //    .imports = .{ .build_options, .persistent_merkle_tree, .ssz, .consensus_types },
+        //},
     },
     .executables = .{
         .download_spec_tests = .{
@@ -128,6 +129,7 @@
                 .imports = .{ .hashing, .zbench },
             },
         },
+        //TODO(bing): reintroduce when bun-ffi generation is fixed
         // .write_bun_ffi = .{
         //     .root_module = .{
         //         .root_source_file = "src/bun_ffi/write_types.zig",


### PR DESCRIPTION
Closes #37

`bun-ffi` bindings are currently broken, causing noise in the output during build/test process. This PR removes them temporarily until they are fixed.