### PR TITLE
feat: support blinded variants of beacon types

### DIFF
--- a/src/consensus_types/bellatrix.zig
+++ b/src/consensus_types/bellatrix.zig
@@ -119,6 +119,32 @@ pub const SignedBeaconBlockHeader = ssz.FixedContainerType(struct {
     signature: p.BLSSignature,
 });
 
+pub const BlindedBeaconBlockBody = ssz.VariableContainerType(struct {
+    randao_reveal: p.BLSSignature,
+    eth1_data: Eth1Data,
+    graffiti: p.Bytes32,
+    proposer_slashings: ssz.FixedListType(ProposerSlashing, preset.MAX_PROPOSER_SLASHINGS),
+    attester_slashings: ssz.VariableListType(AttesterSlashing, preset.MAX_ATTESTER_SLASHINGS),
+    attestations: ssz.VariableListType(Attestation, preset.MAX_ATTESTATIONS),
+    deposits: ssz.FixedListType(Deposit, preset.MAX_DEPOSITS),
+    voluntary_exits: ssz.FixedListType(SignedVoluntaryExit, preset.MAX_VOLUNTARY_EXITS),
+    sync_aggregate: SyncAggregate,
+    execution_payload_header: ExecutionPayloadHeader,
+});
+
+pub const BlindedBeaconBlock = ssz.VariableContainerType(struct {
+    slot: p.Slot,
+    proposer_index: p.ValidatorIndex,
+    parent_root: p.Root,
+    state_root: p.Root,
+    body: BlindedBeaconBlockBody,
+});
+
+pub const SignedBlindedBeaconBlock = ssz.VariableContainerType(struct {
+    message: BlindedBeaconBlock,
+    signature: p.BLSSignature,
+});
+
 pub const BeaconState = ssz.VariableContainerType(struct {
     genesis_time: p.Uint64,
     genesis_validators_root: p.Root,

--- a/src/consensus_types/capella.zig
+++ b/src/consensus_types/capella.zig
@@ -171,6 +171,33 @@ pub const BeaconBlock = ssz.VariableContainerType(struct {
     body: BeaconBlockBody,
 });
 
+pub const BlindedBeaconBlockBody = ssz.VariableContainerType(struct {
+    randao_reveal: p.BLSSignature,
+    eth1_data: Eth1Data,
+    graffiti: p.Bytes32,
+    proposer_slashings: ssz.FixedListType(ProposerSlashing, preset.MAX_PROPOSER_SLASHINGS),
+    attester_slashings: ssz.VariableListType(AttesterSlashing, preset.MAX_ATTESTER_SLASHINGS),
+    attestations: ssz.VariableListType(Attestation, preset.MAX_ATTESTATIONS),
+    deposits: ssz.FixedListType(Deposit, preset.MAX_DEPOSITS),
+    voluntary_exits: ssz.FixedListType(SignedVoluntaryExit, preset.MAX_VOLUNTARY_EXITS),
+    sync_aggregate: SyncAggregate,
+    execution_payload: ExecutionPayloadHeader,
+    bls_to_execution_changes: ssz.FixedListType(SignedBLSToExecutionChange, preset.MAX_BLS_TO_EXECUTION_CHANGES),
+});
+
+pub const BlindedBeaconBlock = ssz.VariableContainerType(struct {
+    slot: p.Slot,
+    proposer_index: p.ValidatorIndex,
+    parent_root: p.Root,
+    state_root: p.Root,
+    body: BlindedBeaconBlockBody,
+});
+
+pub const SignedBlindedBeaconBlock = ssz.FixedContainerType(struct {
+    message: BlindedBeaconBlock,
+    signature: p.BLSSignature,
+});
+
 pub const SignedBeaconBlockHeader = ssz.FixedContainerType(struct {
     message: BeaconBlockHeader,
     signature: p.BLSSignature,

--- a/src/consensus_types/capella.zig
+++ b/src/consensus_types/capella.zig
@@ -181,7 +181,7 @@ pub const BlindedBeaconBlockBody = ssz.VariableContainerType(struct {
     deposits: ssz.FixedListType(Deposit, preset.MAX_DEPOSITS),
     voluntary_exits: ssz.FixedListType(SignedVoluntaryExit, preset.MAX_VOLUNTARY_EXITS),
     sync_aggregate: SyncAggregate,
-    execution_payload: ExecutionPayloadHeader,
+    execution_payload_header: ExecutionPayloadHeader,
     bls_to_execution_changes: ssz.FixedListType(SignedBLSToExecutionChange, preset.MAX_BLS_TO_EXECUTION_CHANGES),
 });
 

--- a/src/consensus_types/capella.zig
+++ b/src/consensus_types/capella.zig
@@ -193,7 +193,7 @@ pub const BlindedBeaconBlock = ssz.VariableContainerType(struct {
     body: BlindedBeaconBlockBody,
 });
 
-pub const SignedBlindedBeaconBlock = ssz.FixedContainerType(struct {
+pub const SignedBlindedBeaconBlock = ssz.VariableContainerType(struct {
     message: BlindedBeaconBlock,
     signature: p.BLSSignature,
 });

--- a/src/consensus_types/deneb.zig
+++ b/src/consensus_types/deneb.zig
@@ -178,6 +178,34 @@ pub const SignedBeaconBlockHeader = ssz.FixedContainerType(struct {
     signature: p.BLSSignature,
 });
 
+pub const BlindedBeaconBlockBody = ssz.VariableContainerType(struct {
+    randao_reveal: p.BLSSignature,
+    eth1_data: Eth1Data,
+    graffiti: p.Bytes32,
+    proposer_slashings: ssz.FixedListType(ProposerSlashing, preset.MAX_PROPOSER_SLASHINGS),
+    attester_slashings: ssz.VariableListType(AttesterSlashing, preset.MAX_ATTESTER_SLASHINGS),
+    attestations: ssz.VariableListType(Attestation, preset.MAX_ATTESTATIONS),
+    deposits: ssz.FixedListType(Deposit, preset.MAX_DEPOSITS),
+    voluntary_exits: ssz.FixedListType(SignedVoluntaryExit, preset.MAX_VOLUNTARY_EXITS),
+    sync_aggregate: SyncAggregate,
+    execution_payload: ExecutionPayloadHeader,
+    bls_to_execution_changes: ssz.FixedListType(SignedBLSToExecutionChange, preset.MAX_BLS_TO_EXECUTION_CHANGES),
+    blob_kzg_commitments: ssz.FixedListType(p.KZGCommitment, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
+});
+
+pub const BlindedBeaconBlock = ssz.VariableContainerType(struct {
+    slot: p.Slot,
+    proposer_index: p.ValidatorIndex,
+    parent_root: p.Root,
+    state_root: p.Root,
+    body: BlindedBeaconBlockBody,
+});
+
+pub const SignedBlindedBeaconBlock = ssz.FixedContainerType(struct {
+    message: BlindedBeaconBlock,
+    signature: p.BLSSignature,
+});
+
 pub const BeaconState = ssz.VariableContainerType(struct {
     genesis_time: p.Uint64,
     genesis_validators_root: p.Root,

--- a/src/consensus_types/deneb.zig
+++ b/src/consensus_types/deneb.zig
@@ -188,7 +188,7 @@ pub const BlindedBeaconBlockBody = ssz.VariableContainerType(struct {
     deposits: ssz.FixedListType(Deposit, preset.MAX_DEPOSITS),
     voluntary_exits: ssz.FixedListType(SignedVoluntaryExit, preset.MAX_VOLUNTARY_EXITS),
     sync_aggregate: SyncAggregate,
-    execution_payload: ExecutionPayloadHeader,
+    execution_payload_header: ExecutionPayloadHeader,
     bls_to_execution_changes: ssz.FixedListType(SignedBLSToExecutionChange, preset.MAX_BLS_TO_EXECUTION_CHANGES),
     blob_kzg_commitments: ssz.FixedListType(p.KZGCommitment, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
 });

--- a/src/consensus_types/deneb.zig
+++ b/src/consensus_types/deneb.zig
@@ -201,7 +201,7 @@ pub const BlindedBeaconBlock = ssz.VariableContainerType(struct {
     body: BlindedBeaconBlockBody,
 });
 
-pub const SignedBlindedBeaconBlock = ssz.FixedContainerType(struct {
+pub const SignedBlindedBeaconBlock = ssz.VariableContainerType(struct {
     message: BlindedBeaconBlock,
     signature: p.BLSSignature,
 });

--- a/src/consensus_types/electra.zig
+++ b/src/consensus_types/electra.zig
@@ -211,6 +211,35 @@ pub const SignedBeaconBlockHeader = ssz.FixedContainerType(struct {
     signature: p.BLSSignature,
 });
 
+pub const BlindedBeaconBlockBody = ssz.VariableContainerType(struct {
+    randao_reveal: p.BLSSignature,
+    eth1_data: Eth1Data,
+    graffiti: p.Bytes32,
+    proposer_slashings: ssz.FixedListType(ProposerSlashing, preset.MAX_PROPOSER_SLASHINGS),
+    attester_slashings: ssz.VariableListType(AttesterSlashing, preset.MAX_ATTESTER_SLASHINGS),
+    attestations: ssz.VariableListType(Attestation, preset.MAX_ATTESTATIONS_ELECTRA),
+    deposits: ssz.FixedListType(Deposit, preset.MAX_DEPOSITS),
+    voluntary_exits: ssz.FixedListType(SignedVoluntaryExit, preset.MAX_VOLUNTARY_EXITS),
+    sync_aggregate: SyncAggregate,
+    execution_payload: ExecutionPayloadHeader,
+    bls_to_execution_changes: ssz.FixedListType(SignedBLSToExecutionChange, preset.MAX_BLS_TO_EXECUTION_CHANGES),
+    blob_kzg_commitments: ssz.FixedListType(p.KZGCommitment, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
+    execution_requests: ExecutionRequests,
+});
+
+pub const BlindedBeaconBlock = ssz.VariableContainerType(struct {
+    slot: p.Slot,
+    proposer_index: p.ValidatorIndex,
+    parent_root: p.Root,
+    state_root: p.Root,
+    body: BlindedBeaconBlockBody,
+});
+
+pub const SignedBlindedBeaconBlock = ssz.FixedContainerType(struct {
+    message: BlindedBeaconBlock,
+    signature: p.BLSSignature,
+});
+
 pub const BeaconState = ssz.VariableContainerType(struct {
     genesis_time: p.Uint64,
     genesis_validators_root: p.Root,

--- a/src/consensus_types/electra.zig
+++ b/src/consensus_types/electra.zig
@@ -235,7 +235,7 @@ pub const BlindedBeaconBlock = ssz.VariableContainerType(struct {
     body: BlindedBeaconBlockBody,
 });
 
-pub const SignedBlindedBeaconBlock = ssz.FixedContainerType(struct {
+pub const SignedBlindedBeaconBlock = ssz.VariableContainerType(struct {
     message: BlindedBeaconBlock,
     signature: p.BLSSignature,
 });

--- a/src/consensus_types/electra.zig
+++ b/src/consensus_types/electra.zig
@@ -221,7 +221,7 @@ pub const BlindedBeaconBlockBody = ssz.VariableContainerType(struct {
     deposits: ssz.FixedListType(Deposit, preset.MAX_DEPOSITS),
     voluntary_exits: ssz.FixedListType(SignedVoluntaryExit, preset.MAX_VOLUNTARY_EXITS),
     sync_aggregate: SyncAggregate,
-    execution_payload: ExecutionPayloadHeader,
+    execution_payload_header: ExecutionPayloadHeader,
     bls_to_execution_changes: ssz.FixedListType(SignedBLSToExecutionChange, preset.MAX_BLS_TO_EXECUTION_CHANGES),
     blob_kzg_commitments: ssz.FixedListType(p.KZGCommitment, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
     execution_requests: ExecutionRequests,


### PR DESCRIPTION
Includes the following new types:
- `BlindedBeaconBlockBody`
- `BlindedBeaconBlock`
- `SignedBlindedBeaconBlock`

Unblocks https://github.com/ChainSafe/state-transition-z/issues/18