### PR TITLE
chore: nuke all usage of `usingnamespace`

### DIFF
--- a/src/hashing/root.zig
+++ b/src/hashing/root.zig
@@ -1,4 +1,16 @@
-pub usingnamespace @import("depth.zig");
-pub usingnamespace @import("sha256.zig");
-pub usingnamespace @import("zero_hash.zig");
-pub usingnamespace @import("merkleize.zig");
+const depth = @import("depth.zig");
+pub const GindexUint = depth.GindexUint;
+pub const max_depth = depth.max_depth;
+pub const Depth = depth.Depth;
+
+const sha256 = @import("sha256.zig");
+pub const hash = sha256.hash;
+pub const hashOne = sha256.hashOne;
+
+const zero_hash = @import("zero_hash.zig");
+pub const getZeroHash = zero_hash.getZeroHash;
+
+const merkleize_ = @import("merkleize.zig");
+pub const merkleize = merkleize_.merkleize;
+pub const mixInLength = merkleize_.mixInLength;
+pub const maxChunksToDepth = merkleize_.maxChunksToDepth;

--- a/src/ssz/root.zig
+++ b/src/ssz/root.zig
@@ -1,6 +1,41 @@
 const std = @import("std");
 const testing = std.testing;
 
-pub usingnamespace @import("type/root.zig");
-pub usingnamespace @import("hasher.zig");
-pub usingnamespace @import("tree_view.zig");
+pub const types = @import("type/root.zig");
+
+pub const TypeKind = types.TypeKind;
+pub const isBasicType = types.isBasicType;
+pub const isFixedType = types.isFixedType;
+
+pub const BoolType = types.BoolType;
+pub const UintType = types.UintType;
+
+pub const BitListType = types.BitListType;
+pub const BitList = types.BitList;
+pub const isBitListType = types.isBitListType;
+
+pub const BitVectorType = types.BitVectorType;
+pub const BitVector = types.BitVector;
+pub const isBitVectorType = types.isBitVectorType;
+
+pub const ByteListType = types.ByteListType;
+pub const isByteListType = types.isByteListType;
+
+pub const ByteVectorType = types.ByteVectorType;
+pub const isByteVectorType = types.isByteVectorType;
+
+pub const FixedListType = types.FixedListType;
+pub const VariableListType = types.VariableListType;
+
+pub const FixedVectorType = types.FixedVectorType;
+pub const VariableVectorType = types.VariableVectorType;
+
+pub const FixedContainerType = types.FixedContainerType;
+pub const VariableContainerType = types.VariableContainerType;
+
+const hasher = @import("hasher.zig");
+pub const Hasher = hasher.Hasher;
+pub const HasherData = hasher.HasherData;
+
+const tree_view = @import("tree_view.zig");
+pub const TreeView = tree_view.TreeView;


### PR DESCRIPTION
`usingnamespace` is removed from the language as of `v0.15.0`: https://github.com/ziglang/zig/issues/20663
