### PR TITLE
test: reintroduce sanity tests

### DIFF
--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -203,8 +203,3 @@ test "BitVectorType - sanity" {
     _ = Bits.serializeIntoBytes(&b, &b_buf);
     try Bits.deserializeFromBytes(&b_buf, &b);
 }
-
-test {
-    std.debug.print("float {d}\n", .{3.14159565});
-    std.debug.print("int {d}\n", .{3});
-}

--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -189,7 +189,7 @@ pub fn BitVectorType(comptime _length: comptime_int) type {
 test "BitVectorType - sanity" {
     const length = 44;
     const Bits = BitVectorType(length);
-    var b: Bits.Type = Bits.Type.init();
+    var b: Bits.Type = Bits.default_value;
     try b.set(0, true);
     try b.set(length - 1, true);
 

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -486,7 +486,7 @@ test "ListType - sanity" {
     // create a fixed list type and instance and round-trip serialize
     const Bytes = FixedListType(UintType(8), 32);
 
-    var b: Bytes.Type = try Bytes.init(allocator);
+    var b: Bytes.Type = Bytes.default_value;
     defer b.deinit(allocator);
     try b.append(allocator, 5);
 
@@ -498,7 +498,7 @@ test "ListType - sanity" {
 
     // create a variable list type and instance and round-trip serialize
     const BytesBytes = VariableListType(Bytes, 32);
-    var b2: BytesBytes.Type = try BytesBytes.init(allocator);
+    var b2: BytesBytes.Type = BytesBytes.default_value;
     defer b2.deinit(allocator);
     try b2.append(allocator, b);
 

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -498,13 +498,14 @@ test "ListType - sanity" {
 
     // create a variable list type and instance and round-trip serialize
     const BytesBytes = VariableListType(Bytes, 32);
-    var b2: BytesBytes.Type = BytesBytes.default_value;
-    defer b2.deinit(allocator);
-    try b2.append(allocator, b);
+    var bb: BytesBytes.Type = BytesBytes.default_value;
+    defer bb.deinit(allocator);
+    const b2: Bytes.Type = Bytes.default_value;
+    try bb.append(allocator, b2);
 
-    const b2_buf = try allocator.alloc(u8, BytesBytes.serializedSize(&b2));
-    defer allocator.free(b2_buf);
+    const bb_buf = try allocator.alloc(u8, BytesBytes.serializedSize(&bb));
+    defer allocator.free(bb_buf);
 
-    _ = BytesBytes.serializeIntoBytes(&b2, b2_buf);
-    try BytesBytes.deserializeFromBytes(allocator, b2_buf, &b2);
+    _ = BytesBytes.serializeIntoBytes(&bb, bb_buf);
+    try BytesBytes.deserializeFromBytes(allocator, bb_buf, &bb);
 }

--- a/src/ssz/type/root.zig
+++ b/src/ssz/type/root.zig
@@ -27,3 +27,17 @@ pub const VariableVectorType = @import("vector.zig").VariableVectorType;
 
 pub const FixedContainerType = @import("container.zig").FixedContainerType;
 pub const VariableContainerType = @import("container.zig").VariableContainerType;
+
+test {
+    _ = @import("bool.zig");
+    _ = @import("uint.zig");
+    _ = @import("vector.zig");
+    _ = @import("bit_list.zig");
+    _ = @import("bit_vector.zig");
+    _ = @import("byte_list.zig");
+    _ = @import("byte_vector.zig");
+    _ = @import("list.zig");
+    _ = @import("container.zig");
+}
+
+const std = @import("std");


### PR DESCRIPTION
Tests were written but not imported in `root.zig`, so they were all not
being run.