### PR TITLE
feat: implement `clone`

### DIFF
--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -217,12 +217,9 @@ pub fn BitListType(comptime _limit: comptime_int) type {
         /// Clones the underlying `ArrayList` in `data`.
         ///
         /// Caller owns the memory.
-        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
-            const cloned = Type{
-                .data = try value.data.clone(allocator),
-                .bit_len = value.bit_len,
-            };
-            return cloned;
+        pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
+            out.data = try value.data.clone(allocator);
+            out.bit_len = value.bit_len;
         }
 
         pub fn serializedSize(value: *const Type) usize {
@@ -520,7 +517,8 @@ test "clone" {
     var b: Bits.Type = try Bits.Type.fromBitLen(allocator, 30);
     defer b.deinit(allocator);
 
-    var cloned = try Bits.clone(allocator, &b);
+    var cloned: Bits.Type = undefined;
+    try Bits.clone(allocator, &b, &cloned);
     defer cloned.deinit(allocator);
 
     try std.testing.expect(&b != &cloned);

--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -214,7 +214,7 @@ pub fn BitListType(comptime _limit: comptime_int) type {
             mixInLength(value.bit_len, out);
         }
 
-        /// Clones the underlying `ArrayList`.
+        /// Clones the underlying `ArrayList` in `data`.
         ///
         /// Caller owns the memory.
         pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {

--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -217,7 +217,7 @@ pub fn BitListType(comptime _limit: comptime_int) type {
         /// Clones the underlying `ArrayList`.
         ///
         /// Caller owns the memory.
-        pub fn deepClone(allocator: std.mem.Allocator, value: *const Type) !Type {
+        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
             const cloned = Type{
                 .data = try value.data.clone(allocator),
                 .bit_len = value.bit_len,
@@ -513,14 +513,14 @@ test "BitListType - intersectValues" {
     }
 }
 
-test "deepClone" {
+test "clone" {
     const allocator = std.testing.allocator;
 
     const Bits = BitListType(40);
     var b: Bits.Type = try Bits.Type.fromBitLen(allocator, 30);
     defer b.deinit(allocator);
 
-    var cloned = try Bits.deepClone(allocator, &b);
+    var cloned = try Bits.clone(allocator, &b);
     defer cloned.deinit(allocator);
 
     try std.testing.expect(&b != &cloned);

--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -522,5 +522,6 @@ test "clone" {
     defer cloned.deinit(allocator);
 
     try std.testing.expect(&b != &cloned);
+    try std.testing.expect(b.bit_len == cloned.bit_len);
     try std.testing.expect(std.mem.eql(u8, b.data.items, cloned.data.items));
 }

--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
+const expectEqualSerializedAlloc = @import("test_utils.zig").expectEqualSerializedAlloc;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const BoolType = @import("bool.zig").BoolType;
 const hexToBytes = @import("hex").hexToBytes;
@@ -526,4 +527,5 @@ test "clone" {
     try std.testing.expect(b.bit_len == cloned.bit_len);
     try std.testing.expect(std.mem.eql(u8, b.data.items, cloned.data.items));
     try expectEqualRootsAlloc(Bits, allocator, b, cloned);
+    try expectEqualSerializedAlloc(Bits, allocator, b, cloned);
 }

--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const BoolType = @import("bool.zig").BoolType;
 const hexToBytes = @import("hex").hexToBytes;
@@ -524,4 +525,5 @@ test "clone" {
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(b.bit_len == cloned.bit_len);
     try std.testing.expect(std.mem.eql(u8, b.data.items, cloned.data.items));
+    try expectEqualRootsAlloc(Bits, allocator, b, cloned);
 }

--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -141,7 +141,7 @@ pub fn BitVectorType(comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn clone(_: std.mem.Allocator, value: *const Type, out: *Type) !void {
+        pub fn clone(value: *const Type, out: *Type) !void {
             out.* = value.*;
         }
 
@@ -299,8 +299,6 @@ test "BitVectorType - intersectValues" {
 }
 
 test "clone" {
-    const allocator = std.testing.allocator;
-
     const length = 44;
     const Bits = BitVectorType(length);
     var b: Bits.Type = Bits.default_value;
@@ -308,7 +306,7 @@ test "clone" {
     try b.set(length - 1, true);
 
     var cloned: Bits.Type = undefined;
-    try Bits.clone(allocator, &b, &cloned);
+    try Bits.clone(&b, &cloned);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.data[0..], cloned.data[0..]));
 

--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
+const expectEqualSerialized = @import("test_utils.zig").expectEqualSerialized;
 const merkleize = @import("hashing").merkleize;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const BoolType = @import("bool.zig").BoolType;
@@ -312,4 +313,5 @@ test "clone" {
     try std.testing.expect(std.mem.eql(u8, b.data[0..], cloned.data[0..]));
 
     try expectEqualRoots(Bits, b, cloned);
+    try expectEqualSerialized(Bits, b, cloned);
 }

--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -139,7 +139,7 @@ pub fn BitVectorType(comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn deepClone(_: std.mem.Allocator, value: *const Type) !Type {
+        pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
             const cloned: Type = value.*;
             return cloned;
         }
@@ -297,7 +297,7 @@ test "BitVectorType - intersectValues" {
     }
 }
 
-test "deepClone" {
+test "clone" {
     // create a fixed vector type and instance and round-trip serialize
 
     const allocator = std.testing.allocator;
@@ -308,7 +308,7 @@ test "deepClone" {
     try b.set(0, true);
     try b.set(length - 1, true);
 
-    var cloned = try Bits.deepClone(allocator, &b);
+    var cloned = try Bits.clone(allocator, &b);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.data[0..], cloned.data[0..]));
 }

--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -298,8 +298,6 @@ test "BitVectorType - intersectValues" {
 }
 
 test "clone" {
-    // create a fixed vector type and instance and round-trip serialize
-
     const allocator = std.testing.allocator;
 
     const length = 44;

--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
 const merkleize = @import("hashing").merkleize;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const BoolType = @import("bool.zig").BoolType;
@@ -309,4 +310,6 @@ test "clone" {
     try Bits.clone(allocator, &b, &cloned);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.data[0..], cloned.data[0..]));
+
+    try expectEqualRoots(Bits, b, cloned);
 }

--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -139,9 +139,8 @@ pub fn BitVectorType(comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
-            const cloned: Type = value.*;
-            return cloned;
+        pub fn clone(_: std.mem.Allocator, value: *const Type, out: *Type) !void {
+            out.* = value.*;
         }
 
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {
@@ -306,7 +305,8 @@ test "clone" {
     try b.set(0, true);
     try b.set(length - 1, true);
 
-    var cloned = try Bits.clone(allocator, &b);
+    var cloned: Bits.Type = undefined;
+    try Bits.clone(allocator, &b, &cloned);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.data[0..], cloned.data[0..]));
 }

--- a/src/ssz/type/bool.zig
+++ b/src/ssz/type/bool.zig
@@ -14,9 +14,8 @@ pub fn BoolType() type {
             return a.* == b.*;
         }
 
-        pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
-            const cloned: Type = value.*;
-            return cloned;
+        pub fn clone(_: std.mem.Allocator, value: *const Type, out: *Type) !void {
+            out.* = value.*;
         }
 
         pub fn hashTreeRoot(value: *const Type, out: *[32]u8) !void {

--- a/src/ssz/type/bool.zig
+++ b/src/ssz/type/bool.zig
@@ -14,6 +14,11 @@ pub fn BoolType() type {
             return a.* == b.*;
         }
 
+        pub fn deepClone(_: std.mem.Allocator, value: *const Type) !Type {
+            const cloned: Type = value.*;
+            return cloned;
+        }
+
         pub fn hashTreeRoot(value: *const Type, out: *[32]u8) !void {
             @memset(out, 0);
             out[0] = if (value.*) 1 else 0;

--- a/src/ssz/type/bool.zig
+++ b/src/ssz/type/bool.zig
@@ -14,7 +14,7 @@ pub fn BoolType() type {
             return a.* == b.*;
         }
 
-        pub fn deepClone(_: std.mem.Allocator, value: *const Type) !Type {
+        pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
             const cloned: Type = value.*;
             return cloned;
         }

--- a/src/ssz/type/bool.zig
+++ b/src/ssz/type/bool.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const TypeKind = @import("type_kind.zig").TypeKind;
+const expectEqualSerialized = @import("test_utils.zig").expectEqualSerialized;
 const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
 const Node = @import("persistent_merkle_tree").Node;
 
@@ -124,4 +125,5 @@ test "BoolType - sanity" {
 
     try expectEqualRoots(Bool, b, cloned);
     try std.testing.expectEqualSlices(u8, input_json, output_json.items);
+    try expectEqualSerialized(Bool, b, cloned);
 }

--- a/src/ssz/type/bool.zig
+++ b/src/ssz/type/bool.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const TypeKind = @import("type_kind.zig").TypeKind;
+const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
 const Node = @import("persistent_merkle_tree").Node;
 
 pub fn BoolType() type {
@@ -118,5 +119,9 @@ test "BoolType - sanity" {
     defer write_stream.deinit();
     try Bool.serializeIntoJson(&write_stream, &b);
 
+    var cloned: Bool.Type = undefined;
+    try Bool.clone(allocator, &b, &cloned);
+
+    try expectEqualRoots(Bool, b, cloned);
     try std.testing.expectEqualSlices(u8, input_json, output_json.items);
 }

--- a/src/ssz/type/bool.zig
+++ b/src/ssz/type/bool.zig
@@ -16,7 +16,7 @@ pub fn BoolType() type {
             return a.* == b.*;
         }
 
-        pub fn clone(_: std.mem.Allocator, value: *const Type, out: *Type) !void {
+        pub fn clone(value: *const Type, out: *Type) !void {
             out.* = value.*;
         }
 
@@ -121,7 +121,7 @@ test "BoolType - sanity" {
     try Bool.serializeIntoJson(&write_stream, &b);
 
     var cloned: Bool.Type = undefined;
-    try Bool.clone(allocator, &b, &cloned);
+    try Bool.clone(&b, &cloned);
 
     try expectEqualRoots(Bool, b, cloned);
     try std.testing.expectEqualSlices(u8, input_json, output_json.items);

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -56,6 +56,9 @@ pub fn ByteListType(comptime _limit: comptime_int) type {
             mixInLength(value.items.len, out);
         }
 
+        /// Clones the underlying `ArrayList`.
+        ///
+        /// Caller owns the memory.
         pub fn clone(allocator: std.mem.Allocator, value: *const Type) !*Type {
             var cloned: Type = try value.clone(allocator);
             return &cloned;

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
+const expectEqualSerializedAlloc = @import("test_utils.zig").expectEqualSerializedAlloc;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const UintType = @import("uint.zig").UintType;
 const hexToBytes = @import("hex").hexToBytes;
@@ -217,4 +218,5 @@ test "clone" {
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.items, cloned.items));
     try expectEqualRootsAlloc(Bits, allocator, b, cloned);
+    try expectEqualSerializedAlloc(Bits, allocator, b, cloned);
 }

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -203,8 +203,6 @@ pub fn ByteListType(comptime _limit: comptime_int) type {
     };
 }
 test "clone" {
-    // create a fixed vector type and instance and round-trip serialize
-
     const allocator = std.testing.allocator;
 
     const length = 44;

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -56,6 +56,11 @@ pub fn ByteListType(comptime _limit: comptime_int) type {
             mixInLength(value.items.len, out);
         }
 
+        pub fn deepClone(allocator: std.mem.Allocator, value: *const Type) !*Type {
+            var cloned: Type = try value.clone(allocator);
+            return &cloned;
+        }
+
         pub fn serializedSize(value: *const Type) usize {
             return value.items.len * Element.fixed_size;
         }
@@ -193,4 +198,18 @@ pub fn ByteListType(comptime _limit: comptime_int) type {
             _ = try hexToBytes(out.items, hex_bytes);
         }
     };
+}
+test "deepClone" {
+    // create a fixed vector type and instance and round-trip serialize
+
+    const allocator = std.testing.allocator;
+
+    const length = 44;
+    const Bits = ByteListType(length);
+    var b = Bits.default_value;
+    defer b.deinit(allocator);
+
+    var cloned = try Bits.deepClone(allocator, &b);
+    try std.testing.expect(&&b != &cloned);
+    try std.testing.expect(std.mem.eql(u8, b.items, cloned.items));
 }

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -208,8 +208,10 @@ test "clone" {
     const Bits = ByteListType(length);
     var b = Bits.default_value;
     defer b.deinit(allocator);
+    try b.append(allocator, 5);
 
     var cloned: Bits.Type = undefined;
+    defer cloned.deinit(allocator);
     try Bits.clone(allocator, &b, &cloned);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.items, cloned.items));

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const UintType = @import("uint.zig").UintType;
 const hexToBytes = @import("hex").hexToBytes;
@@ -215,4 +216,5 @@ test "clone" {
     try Bits.clone(allocator, &b, &cloned);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.items, cloned.items));
+    try expectEqualRootsAlloc(Bits, allocator, b, cloned);
 }

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -56,7 +56,7 @@ pub fn ByteListType(comptime _limit: comptime_int) type {
             mixInLength(value.items.len, out);
         }
 
-        pub fn deepClone(allocator: std.mem.Allocator, value: *const Type) !*Type {
+        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !*Type {
             var cloned: Type = try value.clone(allocator);
             return &cloned;
         }
@@ -199,7 +199,7 @@ pub fn ByteListType(comptime _limit: comptime_int) type {
         }
     };
 }
-test "deepClone" {
+test "clone" {
     // create a fixed vector type and instance and round-trip serialize
 
     const allocator = std.testing.allocator;
@@ -209,7 +209,7 @@ test "deepClone" {
     var b = Bits.default_value;
     defer b.deinit(allocator);
 
-    var cloned = try Bits.deepClone(allocator, &b);
+    var cloned = try Bits.clone(allocator, &b);
     try std.testing.expect(&&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.items, cloned.items));
 }

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -59,9 +59,8 @@ pub fn ByteListType(comptime _limit: comptime_int) type {
         /// Clones the underlying `ArrayList`.
         ///
         /// Caller owns the memory.
-        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
-            const cloned: Type = try value.clone(allocator);
-            return cloned;
+        pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
+            out.* = try value.clone(allocator);
         }
 
         pub fn serializedSize(value: *const Type) usize {
@@ -210,7 +209,8 @@ test "clone" {
     var b = Bits.default_value;
     defer b.deinit(allocator);
 
-    var cloned = try Bits.clone(allocator, &b);
-    try std.testing.expect(&&b != &cloned);
+    var cloned: Bits.Type = undefined;
+    try Bits.clone(allocator, &b, &cloned);
+    try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.items, cloned.items));
 }

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -59,9 +59,9 @@ pub fn ByteListType(comptime _limit: comptime_int) type {
         /// Clones the underlying `ArrayList`.
         ///
         /// Caller owns the memory.
-        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !*Type {
-            var cloned: Type = try value.clone(allocator);
-            return &cloned;
+        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
+            const cloned: Type = try value.clone(allocator);
+            return cloned;
         }
 
         pub fn serializedSize(value: *const Type) usize {

--- a/src/ssz/type/byte_vector.zig
+++ b/src/ssz/type/byte_vector.zig
@@ -41,7 +41,7 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn deepClone(_: std.mem.Allocator, value: *const Type) !Type {
+        pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
             const cloned: Type = value.*;
             return cloned;
         }
@@ -133,7 +133,7 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
     };
 }
 
-test "deepClone" {
+test "clone" {
     // create a fixed vector type and instance and round-trip serialize
 
     const allocator = std.testing.allocator;
@@ -142,7 +142,7 @@ test "deepClone" {
     const Bytes = ByteVectorType(length);
 
     var b = [_]u8{1} ** length;
-    var cloned = try Bytes.deepClone(allocator, &b);
+    var cloned = try Bytes.clone(allocator, &b);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b[0..], cloned[0..]));
 }

--- a/src/ssz/type/byte_vector.zig
+++ b/src/ssz/type/byte_vector.zig
@@ -41,6 +41,11 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
+        pub fn deepClone(_: std.mem.Allocator, value: *const Type) !Type {
+            const cloned: Type = value.*;
+            return cloned;
+        }
+
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {
             @memcpy(out[0..fixed_size], value);
             return length;
@@ -126,4 +131,18 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
             _ = try hexToBytes(out, hex_bytes);
         }
     };
+}
+
+test "deepClone" {
+    // create a fixed vector type and instance and round-trip serialize
+
+    const allocator = std.testing.allocator;
+
+    const length = 44;
+    const Bytes = ByteVectorType(length);
+
+    var b = [_]u8{1} ** length;
+    var cloned = try Bytes.deepClone(allocator, &b);
+    try std.testing.expect(&b != &cloned);
+    try std.testing.expect(std.mem.eql(u8, b[0..], cloned[0..]));
 }

--- a/src/ssz/type/byte_vector.zig
+++ b/src/ssz/type/byte_vector.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const UintType = @import("uint.zig").UintType;
 const hexToBytes = @import("hex").hexToBytes;
@@ -143,4 +144,5 @@ test "clone" {
     try Bytes.clone(allocator, &b, &cloned);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b[0..], cloned[0..]));
+    try expectEqualRoots(Bytes, b, cloned);
 }

--- a/src/ssz/type/byte_vector.zig
+++ b/src/ssz/type/byte_vector.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
+const expectEqualSerialized = @import("test_utils.zig").expectEqualSerialized;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const UintType = @import("uint.zig").UintType;
 const hexToBytes = @import("hex").hexToBytes;
@@ -145,4 +146,5 @@ test "clone" {
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b[0..], cloned[0..]));
     try expectEqualRoots(Bytes, b, cloned);
+    try expectEqualSerialized(Bytes, b, cloned);
 }

--- a/src/ssz/type/byte_vector.zig
+++ b/src/ssz/type/byte_vector.zig
@@ -134,8 +134,6 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
 }
 
 test "clone" {
-    // create a fixed vector type and instance and round-trip serialize
-
     const allocator = std.testing.allocator;
 
     const length = 44;

--- a/src/ssz/type/byte_vector.zig
+++ b/src/ssz/type/byte_vector.zig
@@ -43,7 +43,7 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn clone(_: std.mem.Allocator, value: *const Type, out: *Type) !void {
+        pub fn clone(value: *const Type, out: *Type) !void {
             out.* = value.*;
         }
 
@@ -135,14 +135,12 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
 }
 
 test "clone" {
-    const allocator = std.testing.allocator;
-
     const length = 44;
     const Bytes = ByteVectorType(length);
 
     var b = [_]u8{1} ** length;
     var cloned: [44]u8 = undefined;
-    try Bytes.clone(allocator, &b, &cloned);
+    try Bytes.clone(&b, &cloned);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b[0..], cloned[0..]));
     try expectEqualRoots(Bytes, b, cloned);

--- a/src/ssz/type/byte_vector.zig
+++ b/src/ssz/type/byte_vector.zig
@@ -41,9 +41,8 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
-            const cloned: Type = value.*;
-            return cloned;
+        pub fn clone(_: std.mem.Allocator, value: *const Type, out: *Type) !void {
+            out.* = value.*;
         }
 
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {
@@ -140,7 +139,8 @@ test "clone" {
     const Bytes = ByteVectorType(length);
 
     var b = [_]u8{1} ** length;
-    var cloned = try Bytes.clone(allocator, &b);
+    var cloned: [44]u8 = undefined;
+    try Bytes.clone(allocator, &b, &cloned);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b[0..], cloned[0..]));
 }

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
 const TypeKind = @import("type_kind.zig").TypeKind;
 
 const isFixedType = @import("type_kind.zig").isFixedType;
@@ -668,5 +669,7 @@ test "clone" {
     var cloned_f: Foo.Type = undefined;
     try Foo.clone(allocator, &f, &cloned_f);
     try std.testing.expect(&cloned_f != &f);
+
+    try expectEqualRootsAlloc(Foo, allocator, f, cloned_f);
     // TODO(bing): test equals when ready
 }

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -80,7 +80,7 @@ pub fn FixedContainerType(comptime ST: type) type {
         ///
         /// Caller owns the memory.
         pub fn clone(value: *const Type, out: *Type) !void {
-            inline for (fields) |field| @field(out, field.name) = @field(value, field.name);
+            out.* = value.*;
         }
 
         pub fn hashTreeRoot(value: *const Type, out: *[32]u8) !void {

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -355,6 +355,7 @@ pub fn VariableContainerType(comptime ST: type) type {
             out: *Type,
         ) !void {
             inline for (fields) |field| {
+                @field(out, field.name) = field.type.default_value;
                 try field.type.clone(allocator, &@field(value, field.name), &@field(out, field.name));
             }
         }
@@ -671,6 +672,7 @@ test "clone" {
     defer Foo.deinit(allocator, &f);
     var cloned_f: Foo.Type = undefined;
     try Foo.clone(allocator, &f, &cloned_f);
+    defer Foo.deinit(allocator, &cloned_f);
     try std.testing.expect(&cloned_f != &f);
 
     try expectEqualRootsAlloc(Foo, allocator, f, cloned_f);

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -74,13 +74,14 @@ pub fn FixedContainerType(comptime ST: type) type {
             return true;
         }
 
-        pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
-            var out: Type = default_value;
-            inline for (fields) |field| {
-                @field(out, field.name) = @field(value, field.name);
-            }
+         pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
+             var out: Type = default_value;
+             inline for (fields) |field| {
+                 @field(out, field.name) = @field(value, field.name);
+             }
 
-            return out;
+             return out;
+         }
         }
 
         pub fn hashTreeRoot(value: *const Type, out: *[32]u8) !void {
@@ -343,12 +344,12 @@ pub fn VariableContainerType(comptime ST: type) type {
         }
 
         pub fn clone(
-            _: std.mem.Allocator,
+            allocator: std.mem.Allocator,
             value: *const Type,
         ) !Type {
             var out: Type = default_value;
             inline for (fields) |field| {
-                @field(out, field.name) = @field(value, field.name);
+                @field(out, field.name) = try field.type.clone(allocator, &@field(value, field.name));
             }
 
             return out;

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
+const expectEqualSerializedAlloc = @import("test_utils.zig").expectEqualSerializedAlloc;
 const TypeKind = @import("type_kind.zig").TypeKind;
 
 const isFixedType = @import("type_kind.zig").isFixedType;
@@ -671,5 +672,6 @@ test "clone" {
     try std.testing.expect(&cloned_f != &f);
 
     try expectEqualRootsAlloc(Foo, allocator, f, cloned_f);
+    try expectEqualSerializedAlloc(Foo, allocator, f, cloned_f);
     // TODO(bing): test equals when ready
 }

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -351,10 +351,10 @@ pub fn VariableContainerType(comptime ST: type) type {
             out: *Type,
         ) !void {
             inline for (fields) |field| {
-                @field(out, field.name) = field.type.default_value;
                 if (comptime isFixedType(field.type)) {
                     try field.type.clone(&@field(value, field.name), &@field(out, field.name));
                 } else {
+                    @field(out, field.name) = field.type.default_value;
                     try field.type.clone(allocator, &@field(value, field.name), &@field(out, field.name));
                 }
             }

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -74,6 +74,9 @@ pub fn FixedContainerType(comptime ST: type) type {
             return true;
         }
 
++        /// Creates a new `FixedContainerType` and clones all underlying fields in the container.
++        ///
++        /// Caller owns the memory.
          pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
              var out: Type = default_value;
              inline for (fields) |field| {
@@ -343,6 +346,9 @@ pub fn VariableContainerType(comptime ST: type) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
+        /// Creates a new `VariableContainerType` and clones all underlying fields in the container.
+        ///
+        /// Caller owns the memory.
         pub fn clone(
             allocator: std.mem.Allocator,
             value: *const Type,

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -79,10 +79,12 @@ pub fn FixedContainerType(comptime ST: type) type {
         /// Creates a new `FixedContainerType` and clones all underlying fields in the container.
         ///
         /// Caller owns the memory.
-        pub fn clone(_: std.mem.Allocator, value: *const Type, out: *Type) !void {
-            inline for (fields) |field| {
-                @field(out, field.name) = @field(value, field.name);
-            }
+        pub fn clone(
+            _: std.mem.Allocator,
+            value: *const Type,
+            out: *Type,
+        ) !void {
+            inline for (fields) |field| @field(out, field.name) = @field(value, field.name);
         }
 
         pub fn hashTreeRoot(value: *const Type, out: *[32]u8) !void {

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -654,7 +654,6 @@ test "ContainerType - sanity" {
 
 test "clone" {
     const allocator = std.testing.allocator;
-    // create a fixed container type and instance and round-trip serialize
     const Checkpoint = FixedContainerType(struct {
         slot: UintType(8),
         root: ByteVectorType(32),
@@ -673,4 +672,5 @@ test "clone" {
     defer Foo.deinit(allocator, &f);
     var cloned_f = try Foo.clone(allocator, &f);
     try std.testing.expect(&cloned_f != &f);
+    // TODO(bing): test equals when ready
 }

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -75,10 +75,6 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int) type {
         /// Caller owns the memory.
         pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
             try out.resize(allocator, value.items.len);
-            errdefer {
-                for (0..out.items.len) |i| Element.deinit(allocator, &out.items[i]);
-                out.clearRetainingCapacity();
-            }
 
             for (value.items, 0..) |v, i| {
                 var e: Element.Type = undefined;

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -75,6 +75,11 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int) type {
         /// Caller owns the memory.
         pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
             try out.resize(allocator, value.items.len);
+            errdefer {
+                for (0..out.items.len) |i| Element.deinit(allocator, &out.items[i]);
+                out.clearRetainingCapacity();
+            }
+
             for (value.items, 0..) |v, i| {
                 var e: Element.Type = undefined;
                 try Element.clone(allocator, &v, &e);
@@ -329,6 +334,11 @@ pub fn VariableListType(comptime ST: type, comptime _limit: comptime_int) type {
         /// Caller owns the memory.
         pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
             try out.resize(allocator, value.items.len);
+            errdefer {
+                for (0..out.items.len) |i| Element.deinit(allocator, &out.items[i]);
+                out.clearRetainingCapacity();
+            }
+
             for (value.items, 0..) |v, i| {
                 var e: Element.Type = undefined;
                 try Element.clone(allocator, &v, &e);

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -591,11 +591,8 @@ test "clone" {
 
     var bv: BytesVariable.Type = BytesVariable.default_value;
     defer bv.deinit(allocator);
-    try bv.append(allocator, cloned);
-    for (bv.items) |f| {
-        std.debug.print("{}\n", .{f});
-        std.debug.print("{}\n", .{&&f});
-    }
+    const bb: BytesFixed.Type = BytesFixed.default_value;
+    try bv.append(allocator, bb);
     var cloned_v: BytesVariable.Type = try BytesVariable.clone(allocator, &bv);
     defer cloned_v.deinit(allocator);
     try std.testing.expect(&bv != &cloned_v);

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -78,7 +78,8 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int) type {
 
             for (value.items, 0..) |v, i| {
                 var e: Element.Type = undefined;
-                try Element.clone(allocator, &v, &e);
+                try Element.clone(&v, &e);
+
                 out.items[i] = e;
             }
         }
@@ -330,10 +331,6 @@ pub fn VariableListType(comptime ST: type, comptime _limit: comptime_int) type {
         /// Caller owns the memory.
         pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
             try out.resize(allocator, value.items.len);
-            errdefer {
-                for (0..out.items.len) |i| Element.deinit(allocator, &out.items[i]);
-                out.clearRetainingCapacity();
-            }
 
             for (value.items, 0..) |v, i| {
                 var e: Element.Type = undefined;

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const isBasicType = @import("type_kind.zig").isBasicType;
 const isFixedType = @import("type_kind.zig").isFixedType;
@@ -589,6 +590,7 @@ test "clone" {
     defer cloned.deinit(allocator);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.items[0..], cloned.items[0..]));
+    try expectEqualRootsAlloc(BytesFixed, allocator, b, cloned);
 
     var bv: BytesVariable.Type = BytesVariable.default_value;
     defer bv.deinit(allocator);
@@ -598,5 +600,6 @@ test "clone" {
     try BytesVariable.clone(allocator, &bv, &cloned_v);
     defer cloned_v.deinit(allocator);
     try std.testing.expect(&bv != &cloned_v);
+    try expectEqualRootsAlloc(BytesVariable, allocator, bv, cloned_v);
     // TODO(bing): Equals test
 }

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -328,12 +328,8 @@ pub fn VariableListType(comptime ST: type, comptime _limit: comptime_int) type {
         /// Caller owns the memory.
         pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
             try out.resize(allocator, value.items.len);
-
-            for (value.items, 0..) |v, i| {
-                var e: Element.Type = undefined;
-                try Element.clone(allocator, &v, &e);
-                out.items[i] = e;
-            }
+            for (0..value.items.len) |i|
+                try Element.clone(allocator, &value.items[i], &out.items[i]);
         }
 
         pub fn chunkCount(value: *const Type) usize {

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -590,7 +590,6 @@ test "clone" {
     try b.append(allocator, 5);
 
     var cloned: BytesFixed.Type = try BytesFixed.clone(allocator, &b);
-    // We use cloned for later on, so we don't deinit it
     defer cloned.deinit(allocator);
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.items[0..], cloned.items[0..]));

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -72,7 +72,13 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int) type {
         ///
         /// Caller owns the memory.
         pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
-            const cloned = try value.clone(allocator);
+            var cloned = try Type.initCapacity(allocator, value.*.items.len);
+            cloned.expandToCapacity();
+
+            for (value.items, 0..) |v, i| {
+                const e = try Element.clone(allocator, &v);
+                cloned.items[i] = e;
+            }
             return cloned;
         }
 

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -77,10 +77,7 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int) type {
             try out.resize(allocator, value.items.len);
 
             for (value.items, 0..) |v, i| {
-                var e: Element.Type = undefined;
-                try Element.clone(&v, &e);
-
-                out.items[i] = e;
+                try Element.clone(&v, &out.items[i]);
             }
         }
 

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
+const expectEqualSerializedAlloc = @import("test_utils.zig").expectEqualSerializedAlloc;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const isBasicType = @import("type_kind.zig").isBasicType;
 const isFixedType = @import("type_kind.zig").isFixedType;
@@ -591,6 +592,7 @@ test "clone" {
     try std.testing.expect(&b != &cloned);
     try std.testing.expect(std.mem.eql(u8, b.items[0..], cloned.items[0..]));
     try expectEqualRootsAlloc(BytesFixed, allocator, b, cloned);
+    try expectEqualSerializedAlloc(BytesFixed, allocator, b, cloned);
 
     var bv: BytesVariable.Type = BytesVariable.default_value;
     defer bv.deinit(allocator);
@@ -601,5 +603,6 @@ test "clone" {
     defer cloned_v.deinit(allocator);
     try std.testing.expect(&bv != &cloned_v);
     try expectEqualRootsAlloc(BytesVariable, allocator, bv, cloned_v);
+    try expectEqualSerializedAlloc(BytesVariable, allocator, bv, cloned_v);
     // TODO(bing): Equals test
 }

--- a/src/ssz/type/test_utils.zig
+++ b/src/ssz/type/test_utils.zig
@@ -32,3 +32,33 @@ pub fn expectEqualRootsAlloc(comptime T: type, allocator: std.mem.Allocator, exp
 
     try std.testing.expectEqualSlices(u8, &expected_buf, &actual_buf);
 }
+
+/// Tests that two values of the same type `T` serialize to the same byte array.
+pub fn expectEqualSerialized(comptime T: type, expected: anytype, actual: anytype) !void {
+    assert(@TypeOf(expected) == T.Type);
+    assert(@TypeOf(actual) == T.Type);
+
+    var expected_buf: [T.fixed_size]u8 = undefined;
+    var actual_buf: [T.fixed_size]u8 = undefined;
+
+    _ = T.serializeIntoBytes(&expected, &expected_buf);
+    _ = T.serializeIntoBytes(&actual, &actual_buf);
+    try std.testing.expectEqualSlices(u8, &expected_buf, &actual_buf);
+}
+
+/// Tests that two values of the same type `T` serialize to the same byte array.
+///
+/// Same as `expectEqualSerialized`, except with allocation.
+pub fn expectEqualSerializedAlloc(comptime T: type, allocator: std.mem.Allocator, expected: anytype, actual: anytype) !void {
+    assert(@TypeOf(expected) == T.Type);
+    assert(@TypeOf(actual) == T.Type);
+
+    const expected_buf = try allocator.alloc(u8, T.serializedSize(&expected));
+    defer allocator.free(expected_buf);
+    const actual_buf = try allocator.alloc(u8, T.serializedSize(&actual));
+    defer allocator.free(actual_buf);
+
+    _ = T.serializeIntoBytes(&expected, expected_buf);
+    _ = T.serializeIntoBytes(&actual, actual_buf);
+    try std.testing.expectEqualSlices(u8, expected_buf, actual_buf);
+}

--- a/src/ssz/type/test_utils.zig
+++ b/src/ssz/type/test_utils.zig
@@ -4,10 +4,7 @@ const isFixedType = @import("type_kind.zig").isFixedType;
 const isBitVectorType = @import("bit_vector.zig").isBitVectorType;
 
 /// Tests that two values of the same type `T` hash to the same root.
-pub fn expectEqualRoots(comptime T: type, expected: anytype, actual: anytype) !void {
-    assert(@TypeOf(expected) == T.Type);
-    assert(@TypeOf(actual) == T.Type);
-
+pub fn expectEqualRoots(comptime T: type, expected: T.Type, actual: T.Type) !void {
     var expected_buf: [32]u8 = undefined;
     var actual_buf: [32]u8 = undefined;
 
@@ -20,10 +17,7 @@ pub fn expectEqualRoots(comptime T: type, expected: anytype, actual: anytype) !v
 /// Tests that two values of the same type `T` hash to the same root.
 ///
 /// Same as `expectEqualRoots`, except with allocation.
-pub fn expectEqualRootsAlloc(comptime T: type, allocator: std.mem.Allocator, expected: anytype, actual: anytype) !void {
-    assert(@TypeOf(expected) == T.Type);
-    assert(@TypeOf(actual) == T.Type);
-
+pub fn expectEqualRootsAlloc(comptime T: type, allocator: std.mem.Allocator, expected: T.Type, actual: T.Type) !void {
     var expected_buf: [32]u8 = undefined;
     var actual_buf: [32]u8 = undefined;
 
@@ -34,10 +28,7 @@ pub fn expectEqualRootsAlloc(comptime T: type, allocator: std.mem.Allocator, exp
 }
 
 /// Tests that two values of the same type `T` serialize to the same byte array.
-pub fn expectEqualSerialized(comptime T: type, expected: anytype, actual: anytype) !void {
-    assert(@TypeOf(expected) == T.Type);
-    assert(@TypeOf(actual) == T.Type);
-
+pub fn expectEqualSerialized(comptime T: type, expected: T.Type, actual: T.Type) !void {
     var expected_buf: [T.fixed_size]u8 = undefined;
     var actual_buf: [T.fixed_size]u8 = undefined;
 
@@ -49,10 +40,7 @@ pub fn expectEqualSerialized(comptime T: type, expected: anytype, actual: anytyp
 /// Tests that two values of the same type `T` serialize to the same byte array.
 ///
 /// Same as `expectEqualSerialized`, except with allocation.
-pub fn expectEqualSerializedAlloc(comptime T: type, allocator: std.mem.Allocator, expected: anytype, actual: anytype) !void {
-    assert(@TypeOf(expected) == T.Type);
-    assert(@TypeOf(actual) == T.Type);
-
+pub fn expectEqualSerializedAlloc(comptime T: type, allocator: std.mem.Allocator, expected: T.Type, actual: T.Type) !void {
     const expected_buf = try allocator.alloc(u8, T.serializedSize(&expected));
     defer allocator.free(expected_buf);
     const actual_buf = try allocator.alloc(u8, T.serializedSize(&actual));

--- a/src/ssz/type/test_utils.zig
+++ b/src/ssz/type/test_utils.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const isFixedType = @import("type_kind.zig").isFixedType;
+const isBitVectorType = @import("bit_vector.zig").isBitVectorType;
+
+/// Tests that two values of the same type `T` hash to the same root.
+pub fn expectEqualRoots(comptime T: type, expected: anytype, actual: anytype) !void {
+    assert(@TypeOf(expected) == T.Type);
+    assert(@TypeOf(actual) == T.Type);
+
+    var expected_buf: [32]u8 = undefined;
+    var actual_buf: [32]u8 = undefined;
+
+    try T.hashTreeRoot(&expected, &expected_buf);
+    try T.hashTreeRoot(&actual, &actual_buf);
+
+    try std.testing.expectEqualSlices(u8, &expected_buf, &actual_buf);
+}
+
+/// Tests that two values of the same type `T` hash to the same root.
+///
+/// Same as `expectEqualRoots`, except with allocation.
+pub fn expectEqualRootsAlloc(comptime T: type, allocator: std.mem.Allocator, expected: anytype, actual: anytype) !void {
+    assert(@TypeOf(expected) == T.Type);
+    assert(@TypeOf(actual) == T.Type);
+
+    var expected_buf: [32]u8 = undefined;
+    var actual_buf: [32]u8 = undefined;
+
+    try T.hashTreeRoot(allocator, &expected, &expected_buf);
+    try T.hashTreeRoot(allocator, &actual, &actual_buf);
+
+    try std.testing.expectEqualSlices(u8, &expected_buf, &actual_buf);
+}

--- a/src/ssz/type/uint.zig
+++ b/src/ssz/type/uint.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const TypeKind = @import("type_kind.zig").TypeKind;
 const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
+const expectEqualSerialized = @import("test_utils.zig").expectEqualSerialized;
 const Node = @import("persistent_merkle_tree").Node;
 
 pub fn UintType(comptime bits: comptime_int) type {
@@ -126,6 +127,7 @@ test "UintType - sanity" {
     var cloned: Uint8.Type = undefined;
     try Uint8.clone(allocator, &u, &cloned);
     try expectEqualRoots(Uint8, u, cloned);
+    try expectEqualSerialized(Uint8, u, cloned);
 
     try std.testing.expectEqualSlices(u8, input_json, output_json.items);
 }

--- a/src/ssz/type/uint.zig
+++ b/src/ssz/type/uint.zig
@@ -31,7 +31,7 @@ pub fn UintType(comptime bits: comptime_int) type {
             std.mem.writeInt(Type, out[0..fixed_size], value.*, .little);
         }
 
-        pub fn clone(_: std.mem.Allocator, value: *const Type, out: *Type) !void {
+        pub fn clone(value: *const Type, out: *Type) !void {
             out.* = value.*;
         }
 
@@ -125,7 +125,7 @@ test "UintType - sanity" {
     defer write_stream.deinit();
     try Uint8.serializeIntoJson(&write_stream, &u);
     var cloned: Uint8.Type = undefined;
-    try Uint8.clone(allocator, &u, &cloned);
+    try Uint8.clone(&u, &cloned);
     try expectEqualRoots(Uint8, u, cloned);
     try expectEqualSerialized(Uint8, u, cloned);
 

--- a/src/ssz/type/uint.zig
+++ b/src/ssz/type/uint.zig
@@ -29,6 +29,11 @@ pub fn UintType(comptime bits: comptime_int) type {
             std.mem.writeInt(Type, out[0..fixed_size], value.*, .little);
         }
 
+        pub fn deepClone(_: std.mem.Allocator, value: *const Type) !Type {
+            const cloned: Type = value.*;
+            return cloned;
+        }
+
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {
             std.mem.writeInt(Type, out[0..bytes], value.*, .little);
             return bytes;

--- a/src/ssz/type/uint.zig
+++ b/src/ssz/type/uint.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const TypeKind = @import("type_kind.zig").TypeKind;
+const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
 const Node = @import("persistent_merkle_tree").Node;
 
 pub fn UintType(comptime bits: comptime_int) type {
@@ -122,6 +123,9 @@ test "UintType - sanity" {
     var write_stream = std.json.writeStream(output_json.writer(), .{});
     defer write_stream.deinit();
     try Uint8.serializeIntoJson(&write_stream, &u);
+    var cloned: Uint8.Type = undefined;
+    try Uint8.clone(allocator, &u, &cloned);
+    try expectEqualRoots(Uint8, u, cloned);
 
     try std.testing.expectEqualSlices(u8, input_json, output_json.items);
 }

--- a/src/ssz/type/uint.zig
+++ b/src/ssz/type/uint.zig
@@ -29,7 +29,7 @@ pub fn UintType(comptime bits: comptime_int) type {
             std.mem.writeInt(Type, out[0..fixed_size], value.*, .little);
         }
 
-        pub fn deepClone(_: std.mem.Allocator, value: *const Type) !Type {
+        pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
             const cloned: Type = value.*;
             return cloned;
         }

--- a/src/ssz/type/uint.zig
+++ b/src/ssz/type/uint.zig
@@ -29,9 +29,8 @@ pub fn UintType(comptime bits: comptime_int) type {
             std.mem.writeInt(Type, out[0..fixed_size], value.*, .little);
         }
 
-        pub fn clone(_: std.mem.Allocator, value: *const Type) !Type {
-            const cloned: Type = value.*;
-            return cloned;
+        pub fn clone(_: std.mem.Allocator, value: *const Type, out: *Type) !void {
+            out.* = value.*;
         }
 
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -365,9 +365,7 @@ test "vector - sanity" {
     try Bytes32.deserializeFromBytes(&b0_buf, &b0);
 }
 
-test "clonee" {
-    // create a fixed vector type and instance and round-trip serialize
-
+test "clone" {
     const allocator = std.testing.allocator;
     const BoolVectorFixed = FixedVectorType(BoolType(), 8);
     var bvf: BoolVectorFixed.Type = BoolVectorFixed.default_value;

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -53,7 +53,7 @@ pub fn FixedVectorType(comptime ST: type, comptime _length: comptime_int) type {
         }
 
         pub fn clone(value: *const Type, out: *Type) !void {
-            for (0..length) |i| try Element.clone(&value[i], &out[i]);
+            out.* = value.*;
         }
 
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
 const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
+const expectEqualSerializedAlloc = @import("test_utils.zig").expectEqualSerializedAlloc;
+const expectEqualSerialized = @import("test_utils.zig").expectEqualSerialized;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const isBasicType = @import("type_kind.zig").isBasicType;
 const isFixedType = @import("type_kind.zig").isFixedType;
@@ -367,6 +369,7 @@ test "clone" {
     var cloned: BoolVectorFixed.Type = undefined;
     try BoolVectorFixed.clone(allocator, &bvf, &cloned);
     try expectEqualRoots(BoolVectorFixed, bvf, cloned);
+    try expectEqualSerialized(BoolVectorFixed, bvf, cloned);
 
     try std.testing.expect(&bvf != &cloned);
     try std.testing.expect(std.mem.eql(bool, bvf[0..], cloned[0..]));
@@ -382,4 +385,5 @@ test "clone" {
     try BoolVectorVariable.clone(allocator, &bvv, &cloned_v);
     try std.testing.expect(&bvv != &cloned_v);
     try expectEqualRootsAlloc(BoolVectorVariable, allocator, bvv, cloned_v);
+    try expectEqualSerializedAlloc(BoolVectorVariable, allocator, bvv, cloned_v);
 }

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -52,8 +52,8 @@ pub fn FixedVectorType(comptime ST: type, comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
-            for (0..length) |i| try Element.clone(allocator, &value[i], &out[i]);
+        pub fn clone(value: *const Type, out: *Type) !void {
+            for (0..length) |i| try Element.clone(&value[i], &out[i]);
         }
 
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {
@@ -367,7 +367,7 @@ test "clone" {
     var bvf: BoolVectorFixed.Type = BoolVectorFixed.default_value;
 
     var cloned: BoolVectorFixed.Type = undefined;
-    try BoolVectorFixed.clone(allocator, &bvf, &cloned);
+    try BoolVectorFixed.clone(&bvf, &cloned);
     try expectEqualRoots(BoolVectorFixed, bvf, cloned);
     try expectEqualSerialized(BoolVectorFixed, bvf, cloned);
 

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -51,9 +51,7 @@ pub fn FixedVectorType(comptime ST: type, comptime _length: comptime_int) type {
         pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
             var cloned = [_]Element.Type{Element.default_value} ** length;
 
-            for (0..length) |i| {
-                cloned[i] = try Element.clone(allocator, &value[i]);
-            }
+            for (0..length) |i| cloned[i] = try Element.clone(allocator, &value[i]);
 
             return cloned;
         }
@@ -231,9 +229,7 @@ pub fn VariableVectorType(comptime ST: type, comptime _length: comptime_int) typ
         pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
             var cloned = [_]Element.Type{Element.default_value} ** length;
 
-            for (0..length) |i| {
-                cloned[i] = try Element.clone(allocator, &value[i]);
-            }
+            for (0..length) |i| cloned[i] = try Element.clone(allocator, &value[i]);
 
             return cloned;
         }

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const expectEqualRoots = @import("test_utils.zig").expectEqualRoots;
+const expectEqualRootsAlloc = @import("test_utils.zig").expectEqualRootsAlloc;
 const TypeKind = @import("type_kind.zig").TypeKind;
 const isBasicType = @import("type_kind.zig").isBasicType;
 const isFixedType = @import("type_kind.zig").isFixedType;
@@ -364,6 +366,7 @@ test "clone" {
 
     var cloned: BoolVectorFixed.Type = undefined;
     try BoolVectorFixed.clone(allocator, &bvf, &cloned);
+    try expectEqualRoots(BoolVectorFixed, bvf, cloned);
 
     try std.testing.expect(&bvf != &cloned);
     try std.testing.expect(std.mem.eql(bool, bvf[0..], cloned[0..]));
@@ -378,4 +381,5 @@ test "clone" {
     var cloned_v: BoolVectorVariable.Type = undefined;
     try BoolVectorVariable.clone(allocator, &bvv, &cloned_v);
     try std.testing.expect(&bvv != &cloned_v);
+    try expectEqualRootsAlloc(BoolVectorVariable, allocator, bvv, cloned_v);
 }

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -48,12 +48,8 @@ pub fn FixedVectorType(comptime ST: type, comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
-            var cloned = [_]Element.Type{Element.default_value} ** length;
-
-            for (0..length) |i| cloned[i] = try Element.clone(allocator, &value[i]);
-
-            return cloned;
+        pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
+            for (0..length) |i| try Element.clone(allocator, &value[i], &out[i]);
         }
 
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {
@@ -226,12 +222,8 @@ pub fn VariableVectorType(comptime ST: type, comptime _length: comptime_int) typ
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
-            var cloned = [_]Element.Type{Element.default_value} ** length;
-
-            for (0..length) |i| cloned[i] = try Element.clone(allocator, &value[i]);
-
-            return cloned;
+        pub fn clone(allocator: std.mem.Allocator, value: *const Type, out: *Type) !void {
+            for (0..length) |i| try Element.clone(allocator, &value[i], &out[i]);
         }
 
         pub fn serializedSize(value: *const Type) usize {
@@ -370,7 +362,8 @@ test "clone" {
     const BoolVectorFixed = FixedVectorType(BoolType(), 8);
     var bvf: BoolVectorFixed.Type = BoolVectorFixed.default_value;
 
-    var cloned = try BoolVectorFixed.clone(allocator, &bvf);
+    var cloned: BoolVectorFixed.Type = undefined;
+    try BoolVectorFixed.clone(allocator, &bvf, &cloned);
 
     try std.testing.expect(&bvf != &cloned);
     try std.testing.expect(std.mem.eql(bool, bvf[0..], cloned[0..]));
@@ -382,6 +375,7 @@ test "clone" {
     var bvv: BoolVectorVariable.Type = BoolVectorVariable.default_value;
     bvv[0] = bl;
 
-    var cloned_v = try BoolVectorVariable.clone(allocator, &bvv);
+    var cloned_v: BoolVectorVariable.Type = undefined;
+    try BoolVectorVariable.clone(allocator, &bvv, &cloned_v);
     try std.testing.expect(&bvv != &cloned_v);
 }

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -48,11 +48,11 @@ pub fn FixedVectorType(comptime ST: type, comptime _length: comptime_int) type {
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn deepClone(allocator: std.mem.Allocator, value: *const Type) !Type {
+        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
             var cloned = [_]Element.Type{Element.default_value} ** length;
 
             for (0..length) |i| {
-                cloned[i] = try Element.deepClone(allocator, &value[i]);
+                cloned[i] = try Element.clone(allocator, &value[i]);
             }
 
             return cloned;
@@ -228,11 +228,11 @@ pub fn VariableVectorType(comptime ST: type, comptime _length: comptime_int) typ
             try merkleize(@ptrCast(&chunks), chunk_depth, out);
         }
 
-        pub fn deepClone(allocator: std.mem.Allocator, value: *const Type) !Type {
+        pub fn clone(allocator: std.mem.Allocator, value: *const Type) !Type {
             var cloned = [_]Element.Type{Element.default_value} ** length;
 
             for (0..length) |i| {
-                cloned[i] = try Element.deepClone(allocator, &value[i]);
+                cloned[i] = try Element.clone(allocator, &value[i]);
             }
 
             return cloned;
@@ -369,14 +369,14 @@ test "vector - sanity" {
     try Bytes32.deserializeFromBytes(&b0_buf, &b0);
 }
 
-test "deepClonee" {
+test "clonee" {
     // create a fixed vector type and instance and round-trip serialize
 
     const allocator = std.testing.allocator;
     const BoolVectorFixed = FixedVectorType(BoolType(), 8);
     var bvf: BoolVectorFixed.Type = BoolVectorFixed.default_value;
 
-    var cloned = try BoolVectorFixed.deepClone(allocator, &bvf);
+    var cloned = try BoolVectorFixed.clone(allocator, &bvf);
 
     try std.testing.expect(&bvf != &cloned);
     try std.testing.expect(std.mem.eql(bool, bvf[0..], cloned[0..]));
@@ -388,6 +388,6 @@ test "deepClonee" {
     var bvv: BoolVectorVariable.Type = BoolVectorVariable.default_value;
     bvv[0] = bl;
 
-    var cloned_v = try BoolVectorVariable.deepClone(allocator, &bvv);
+    var cloned_v = try BoolVectorVariable.clone(allocator, &bvv);
     try std.testing.expect(&bvv != &cloned_v);
 }

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -361,43 +361,21 @@ test "clone" {
     const allocator = std.testing.allocator;
     const BoolVectorFixed = FixedVectorType(BoolType(), 8);
     var bvf: BoolVectorFixed.Type = BoolVectorFixed.default_value;
-    bvf[0] = true;
-    bvf[2] = true;
 
-    const num_to_clone: comptime_int = 1_000_000;
+    var cloned: BoolVectorFixed.Type = undefined;
+    try BoolVectorFixed.clone(allocator, &bvf, &cloned);
 
-    std.debug.print("Starting fixed clone: {}\n", .{num_to_clone});
-    var timer = try std.time.Timer.start();
-
-    for (0..num_to_clone) |_| {
-        var cloned: BoolVectorFixed.Type = undefined;
-        try BoolVectorFixed.clone(allocator, &bvf, &cloned);
-    }
-    var stop = timer.read();
-    std.debug.print("Done: took {}ns to clone {} times \n", .{ stop, num_to_clone });
+    try std.testing.expect(&bvf != &cloned);
+    try std.testing.expect(std.mem.eql(bool, bvf[0..], cloned[0..]));
 
     const limit = 16;
     const BitList = BitListType(limit);
-    var bl = BitList.default_value;
-    try bl.data.append(allocator, 1);
-    defer bl.deinit(allocator);
+    const bl = BitList.default_value;
     const BoolVectorVariable = VariableVectorType(BitList, 8);
     var bvv: BoolVectorVariable.Type = BoolVectorVariable.default_value;
     bvv[0] = bl;
 
-    var clones: std.ArrayList(BoolVectorVariable.Type) = try std.ArrayList(BoolVectorVariable.Type).initCapacity(allocator, num_to_clone);
-    defer for (0..num_to_clone) |i| {
-        defer BoolVectorVariable.deinit(allocator, &clones.items[i]);
-    };
-    defer clones.deinit();
-
-    try clones.appendNTimes(BoolVectorVariable.default_value, num_to_clone);
-
-    std.debug.print("Starting var clone: {}\n", .{num_to_clone});
-    timer.reset();
-    for (0..num_to_clone) |i| {
-        try BoolVectorVariable.clone(allocator, &bvv, &clones.items[i]);
-    }
-    stop = timer.read();
-    std.debug.print("Done: took {}ms to clone {} times \n", .{ stop / std.math.pow(u64, 10, 6), num_to_clone });
+    var cloned_v: BoolVectorVariable.Type = undefined;
+    try BoolVectorVariable.clone(allocator, &bvv, &cloned_v);
+    try std.testing.expect(&bvv != &cloned_v);
 }


### PR DESCRIPTION
closes #31 

Some implementation details: in certain data types we can copy simply by assignment (like the primitives) but we must be careful to use the underlying `.clone()` api whenever possible especially when it comes to, for example, the container/array types.