### PR TITLE
test(types): actually include types within tests

### DIFF
--- a/src/ssz/root.zig
+++ b/src/ssz/root.zig
@@ -39,3 +39,7 @@ pub const HasherData = hasher.HasherData;
 
 const tree_view = @import("tree_view.zig");
 pub const TreeView = tree_view.TreeView;
+
+test {
+    testing.refAllDecls(@This());
+}


### PR DESCRIPTION
So the previous [PR](https://github.com/ChainSafe/ssz-z/pull/50) didn't fix it; we need to reimport again from the top-level `root.zig`.

To confirm: running `zig build test:ssz --summary all` shows 8 tests passing, remove the import and no tests will be ran.