### PR TITLE
fix: test ref all decls recursively in persistent_merkle_tree

### DIFF
--- a/src/persistent_merkle_tree/Node.zig
+++ b/src/persistent_merkle_tree/Node.zig
@@ -703,7 +703,7 @@ pub const Id = enum(u32) {
         var path_rights_buf: [max_depth]Id = undefined;
 
         // TODO how to handle failing to resize here, especially after several allocs
-        errdefer pool.free(path_parents_buf);
+        errdefer pool.free(&path_parents_buf);
 
         var node_id = root_node;
         // The depth offset to start from, going from the current gindex to the next
@@ -766,7 +766,7 @@ pub const Id = enum(u32) {
             d_offset = if (i == gindices.len - 1)
                 path_len - gindex.pathLen()
             else
-                path_len - @as(Depth, @ctz(gindex ^ gindices[i + 1]));
+                path_len - @as(Depth, @intCast(@ctz(@intFromEnum(gindex) ^ @intFromEnum(gindices[i + 1]))));
 
             // Rebind upwards depth diff times
             try pool.rebind(
@@ -797,7 +797,7 @@ pub fn fillToDepth(pool: *Pool, bottom: Id, depth: Depth, should_ref: bool) Erro
 
 /// Fill a view to the specified length and depth, returning the new root node id.
 pub fn fillToLength(pool: *Pool, leaf: Id, depth: Depth, length: usize, should_ref: bool) Error!Id {
-    const max_length = @as(Gindex, 1) << depth;
+    const max_length = @as(Gindex.Uint, 1) << depth;
     if (length > max_length) {
         return Error.InvalidLength;
     }
@@ -811,7 +811,7 @@ pub fn fillToLength(pool: *Pool, leaf: Id, depth: Depth, length: usize, should_r
     }
 
     // otherwise, traverse down to the specified length
-    const gindex: Gindex = @intCast(max_length | length);
+    const gindex: Gindex = @enumFromInt(max_length | length);
     const path_len = gindex.pathLen();
     var path = gindex.toPath();
 

--- a/src/persistent_merkle_tree/View.zig
+++ b/src/persistent_merkle_tree/View.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Node = @import("Node.zig");
 const Gindex = @import("gindex.zig").Gindex;
+const Depth = @import("hashing").Depth;
 
 const View = @This();
 
@@ -101,7 +102,7 @@ pub const Pool = struct {
             }
         }
         // unref the root node
-        self.unref(view.root_node);
+        self.node_pool.unref(view.root_node);
         // push to the free list
         view.next_free = self.next_free;
         self.next_free = view_id;
@@ -201,11 +202,11 @@ pub const Id = enum(u32) {
         }
     }
 
-    pub fn getNodeAtDepth(self: View.Id, pool: *Pool, depth: Node.Depth, index: usize) Node.Error!Node.Id {
+    pub fn getNodeAtDepth(self: View.Id, pool: *Pool, depth: Depth, index: usize) Node.Error!Node.Id {
         return pool.views.items[@intFromEnum(self)].root_node.getNodeAtDepth(pool.node_pool, depth, index);
     }
 
-    pub fn setNodeAtDepth(self: View.Id, pool: *Pool, depth: Node.Depth, index: usize, node: Node.Id) Node.Error!void {
+    pub fn setNodeAtDepth(self: View.Id, pool: *Pool, depth: Depth, index: usize, node: Node.Id) Node.Error!void {
         const view = &pool.views.items[@intFromEnum(self)];
         const new_root = try view.root_node.setNodeAtDepth(pool.node_pool, depth, index, node);
 
@@ -222,11 +223,11 @@ pub const Id = enum(u32) {
         }
     }
 
-    pub fn getNodesAtDepth(self: View.Id, pool: *Pool, depth: Node.Depth, start_index: usize, out: []Node.Id) Node.Error!void {
+    pub fn getNodesAtDepth(self: View.Id, pool: *Pool, depth: Depth, start_index: usize, out: []Node.Id) Node.Error!void {
         try pool.views.items[@intFromEnum(self)].root_node.getNodesAtDepth(pool.node_pool, depth, start_index, out);
     }
 
-    pub fn setNodesAtDepth(self: View.Id, pool: *Pool, depth: Node.Depth, indices: []usize, nodes: []Node.Id) Node.Error!void {
+    pub fn setNodesAtDepth(self: View.Id, pool: *Pool, depth: Depth, indices: []usize, nodes: []Node.Id) Node.Error!void {
         const view = &pool.views.items[@intFromEnum(self)];
         const new_root = try view.root_node.setNodesAtDepth(pool.node_pool, depth, indices, nodes);
 

--- a/src/persistent_merkle_tree/root.zig
+++ b/src/persistent_merkle_tree/root.zig
@@ -10,5 +10,5 @@ pub const Node = @import("Node.zig");
 pub const View = @import("View.zig");
 
 test {
-    testing.refAllDecls(@This());
+    testing.refAllDeclsRecursive(@This());
 }


### PR DESCRIPTION
- noticed compile errors when using several functions
- use `refAllDeclsRecursive` in module-level test to ensure no obvious regressions