### PR TITLE
Fix test in List_composite

### DIFF
--- a/test/int/type/list_composite.zig
+++ b/test/int/type/list_composite.zig
@@ -74,7 +74,7 @@ test "VariableListType of FixedList" {
             .json =
             \\[["1","2"],["3","4"]]
             ,
-            .rootHex = "0x0000000000000000000000000000000000000000000000000000000000000000",
+            .rootHex = "0x58140d48f9c24545c1e3a50f1ebcca85fd40433c9859c0ac34342fc8e0a800b8",
         },
         TestCase{
             .id = "2 empty values",


### PR DESCRIPTION
As we can see here https://github.com/ChainSafe/ssz/blob/7f5580c2ea69f9307300ddb6010a8bc7ce2fc471/packages/ssz/test/unit/byType/listComposite/valid.test.ts#L76C14-L76C80, the current roothex is incorrect. 