### PR TITLE
fix: setNodes api

### DIFF
--- a/src/persistent_merkle_tree/Node.zig
+++ b/src/persistent_merkle_tree/Node.zig
@@ -766,7 +766,8 @@ pub const Id = enum(u32) {
             d_offset = if (i == gindices.len - 1)
                 path_len - gindex.pathLen()
             else
-                path_len - @as(Depth, @intCast(@ctz(@intFromEnum(gindex) ^ @intFromEnum(gindices[i + 1]))));
+                // path_len - @as(Depth, @intCast(@ctz(@intFromEnum(gindex) ^ @intFromEnum(gindices[i + 1]))));
+                path_len - @as(Depth, @intCast(@bitSizeOf(usize) - @clz(@intFromEnum(gindex) ^ @intFromEnum(gindices[i + 1]))));
 
             // Rebind upwards depth diff times
             try pool.rebind(

--- a/src/persistent_merkle_tree/Node.zig
+++ b/src/persistent_merkle_tree/Node.zig
@@ -766,7 +766,6 @@ pub const Id = enum(u32) {
             d_offset = if (i == gindices.len - 1)
                 path_len - gindex.pathLen()
             else
-                // path_len - @as(Depth, @intCast(@ctz(@intFromEnum(gindex) ^ @intFromEnum(gindices[i + 1]))));
                 path_len - @as(Depth, @intCast(@bitSizeOf(usize) - @clz(@intFromEnum(gindex) ^ @intFromEnum(gindices[i + 1]))));
 
             // Rebind upwards depth diff times

--- a/src/persistent_merkle_tree/root.zig
+++ b/src/persistent_merkle_tree/root.zig
@@ -11,4 +11,5 @@ pub const View = @import("View.zig");
 
 test {
     testing.refAllDeclsRecursive(@This());
+    testing.refAllDecls(@import("node_test.zig"));
 }

--- a/test/int/type/tree_view.zig
+++ b/test/int/type/tree_view.zig
@@ -16,50 +16,49 @@ test "TreeView" {
     };
 
     const root_node = try Checkpoint.tree.fromValue(&pool, &checkpoint);
-    var view = try ssz.TreeView(Checkpoint).init(std.testing.allocator, &pool, root_node);
-    defer view.deinit();
+    var cp_view = try ssz.TreeView(Checkpoint).init(std.testing.allocator, &pool, root_node);
+    defer cp_view.deinit();
 
     // get field "epoch"
-    try std.testing.expectEqual(42, try view.getField("epoch"));
+    try std.testing.expectEqual(42, try cp_view.getField("epoch"));
 
     // get field "root"
-    var root_view = try view.getField("root");
+    var root_view = try cp_view.getField("root");
     var root = [_]u8{0} ** 32;
     const RootView = ssz.TreeView(Checkpoint).Field("root");
     try RootView.SszType.tree.toValue(root_view.data.root, &pool, root[0..]);
     try std.testing.expectEqualSlices(u8, ([_]u8{1} ** 32)[0..], root[0..]);
 
     // modify field "epoch"
-    try view.setField("epoch", 100);
-    try std.testing.expectEqual(100, try view.getField("epoch"));
+    try cp_view.setField("epoch", 100);
+    try std.testing.expectEqual(100, try cp_view.getField("epoch"));
 
     // modify field "root"
     var new_root = [_]u8{2} ** 32;
     const new_root_node = try RootView.SszType.tree.fromValue(&pool, &new_root);
     const new_root_view = try RootView.init(std.testing.allocator, &pool, new_root_node);
-    try view.setField("root", new_root_view);
+    try cp_view.setField("root", new_root_view);
 
     // confirm "root" has been modified
-    root_view = try view.getField("root");
+    root_view = try cp_view.getField("root");
     try RootView.SszType.tree.toValue(root_view.data.root, &pool, root[0..]);
     try std.testing.expectEqualSlices(u8, ([_]u8{2} ** 32)[0..], root[0..]);
 
     // commit and check hash_tree_root
-    // TODO: fix setNodes() api
-    // try view.commit();
-    // var htr_from_value: [32]u8 = undefined;
-    // const expected_checkpoint: Checkpoint.Type = .{
-    //     .epoch = 100,
-    //     .root = [_]u8{2} ** 32,
-    // };
-    // try Checkpoint.hashTreeRoot(&expected_checkpoint, &htr_from_value);
+    try cp_view.commit();
+    var htr_from_value: [32]u8 = undefined;
+    const expected_checkpoint: Checkpoint.Type = .{
+        .epoch = 100,
+        .root = [_]u8{2} ** 32,
+    };
+    try Checkpoint.hashTreeRoot(&expected_checkpoint, &htr_from_value);
 
-    // var htr_from_tree: [32]u8 = undefined;
-    // try view.hashTreeRoot(&htr_from_tree);
+    var htr_from_tree: [32]u8 = undefined;
+    try cp_view.hashTreeRoot(&htr_from_tree);
 
-    // try std.testing.expectEqualSlices(
-    //     u8,
-    //     &htr_from_value,
-    //     &htr_from_tree,
-    // );
+    try std.testing.expectEqualSlices(
+        u8,
+        &htr_from_value,
+        &htr_from_tree,
+    );
 }


### PR DESCRIPTION
**Motivation**
- cannot commit TreeView because setNodes() api was broken

**Description**
- add `node_test.zig` to build process
- write new test and reproduce the issue in `persistent-merkle-tree`

Closes #60 
