### PR TITLE
fix: handle shrinking in BitList.resize()

### DIFF
--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -577,3 +577,26 @@ test "clone" {
     try expectEqualRootsAlloc(Bits, allocator, b, cloned);
     try expectEqualSerializedAlloc(Bits, allocator, b, cloned);
 }
+
+test "resize" {
+    const allocator = std.testing.allocator;
+
+    const Bits = BitListType(16);
+    // First byte: 1, 0, 1, 1, 0, 1, 0, 1 = 173
+    // Second byte: 1, 0, 1, 1, 1, 0, 1, 1 = 221
+    const bools = [_]bool{ true, false, true, true, false, true, false, true, true, false, true, true, true, false, true, true };
+    var b: Bits.Type = try Bits.Type.fromBoolSlice(allocator, &bools);
+    defer b.deinit(allocator);
+
+    try std.testing.expect(b.data.items.len == 2);
+    try std.testing.expect(b.data.items[0] == 173);
+    try std.testing.expect(b.data.items[1] == 221);
+
+    // Resize to 5 bits. Now it should only have one byte,
+    // with the last 3 bits in the byte being wiped out.
+    // First byte: 1, 0, 1, 1, 0, 0, 0, 0 = 13
+    try b.resize(allocator, 5);
+
+    try std.testing.expect(b.data.items.len == 1);
+    try std.testing.expect(b.data.items[0] == 13);
+}

--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -123,11 +123,19 @@ pub fn BitList(comptime limit: comptime_int) type {
             const old_byte_len = std.math.divCeil(usize, self.bit_len, 8) catch unreachable;
             const byte_len = std.math.divCeil(usize, bit_len, 8) catch unreachable;
             try self.data.resize(allocator, byte_len);
-            self.bit_len = bit_len;
             // zero out additionally allocated bytes
             if (old_byte_len < byte_len) {
                 @memset(self.data.items[old_byte_len..], 0);
+            } else {
+                // In the case of old_byte_len >= byte_len, we need to manually zero out the
+                // trailing bits after the last bit
+                const remainder_bits = bit_len % 8;
+                if (remainder_bits != 0) {
+                    const mask: u8 = (@as(u8, 1) << @intCast(remainder_bits)) - 1;
+                    self.data.items[byte_len - 1] &= mask;
+                }
             }
+            self.bit_len = bit_len;
         }
 
         /// Set bit value at index `bit_index`


### PR DESCRIPTION
As discussed in https://github.com/ChainSafe/ssz-z/pull/54#discussion_r2362545689

we should handle the shrinking case in `BitList` ie. calling resize() with `bit_len` shorter than current `bit_len`, to ensure trailing bits are always 0.