### PR TITLE
chore: update dependencies

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,11 +6,11 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const dep_hashtree = b.dependency("hashtree", .{});
+
     const dep_snappy = b.dependency("snappy", .{});
 
     const dep_yaml = b.dependency("yaml", .{});
-
-    const dep_hashtree = b.dependency("hashtree", .{});
 
     const dep_zbench = b.dependency("zbench", .{});
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,17 +6,17 @@
     .fingerprint = 0x1d34bd0ccc66e4c8,
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
+        .hashtree = .{
+            .url = "git+https://github.com/chainsafe/hashtree-z#43a58b0fd4813515cda3d0ffc622125243a01c54",
+            .hash = "hashtree-0.1.0-sBOovrYSAAArAQVa-a6BhOPWPTrgKrJtufxWjQYMNNAN",
+        },
+        .snappy = .{
+            .url = "git+https://github.com/chainsafe/snappy.zig#ede2ad602ac9ffa506e3724a2bf5fc14c806187f",
+            .hash = "snappy-0.1.0-n4AaqtMYAACgB1kHWQ2_CFI-gbtYEUCbXyYlQZ2ENyfd",
+        },
         .yaml = .{
             .url = "git+https://github.com/chainsafe/zig-yaml#e0e5962579e990a66c21424416c7ac092b20b772",
             .hash = "zig_yaml-0.1.0-C1161m2NAgDhth5OvjG1o1UNKcdo-XNfO82m10J1g4Cl",
-        },
-        .snappy = .{
-            .url = "git+https://github.com/chainsafe/snappy#7f30207aadbf9509b51ce9e0d4cdb7ae83a2a86e",
-            .hash = "snappy-0.1.0-n4Aaqnm2AgAAPFpcJoE2b7uCXteQ4LvhceYrwDrn02LM",
-        },
-        .hashtree = .{
-            .url = "git+https://github.com/ChainSafe/hashtree-z#6b96e3f0c7c1cc935bd9cfe1cfcbce84ed5a396a",
-            .hash = "hashtree-0.1.0-sBOovqq8DACfez1ldXMSZ6qr_-yZPCbSv9d9o8G16uU3",
         },
         .zbench = .{
             .url = "git+https://github.com/hendriknielaender/zBench#d8c7dd485306b88b757d52005614ebcb0a336942",

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -9,14 +9,14 @@
         "src",
     },
     .dependencies = .{
+        .hashtree = .{
+            .url = "git+https://github.com/chainsafe/hashtree-z#43a58b0fd4813515cda3d0ffc622125243a01c54",
+        },
         .snappy = .{
-            .url = "git+https://github.com/chainsafe/snappy#7f30207aadbf9509b51ce9e0d4cdb7ae83a2a86e",
+            .url = "git+https://github.com/chainsafe/snappy.zig#ede2ad602ac9ffa506e3724a2bf5fc14c806187f",
         },
         .yaml = .{
             .url = "git+https://github.com/chainsafe/zig-yaml#e0e5962579e990a66c21424416c7ac092b20b772",
-        },
-        .hashtree = .{
-            .url = "git+https://github.com/ChainSafe/hashtree-z#6b96e3f0c7c1cc935bd9cfe1cfcbce84ed5a396a",
         },
         .zbench = .{
             .url = "git+https://github.com/hendriknielaender/zBench#d8c7dd485306b88b757d52005614ebcb0a336942",


### PR DESCRIPTION
- update snappy and hashtree dependency (no code change, just update of their zig build)